### PR TITLE
Update tools

### DIFF
--- a/18.04/ubuntu-debug/Dockerfile
+++ b/18.04/ubuntu-debug/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/cybozu/golang:1.17-focal AS builder
+FROM quay.io/cybozu/golang:1.18-focal AS builder
 
 WORKDIR /go/src/github.com/fullstorydev/grpcurl
-ARG GRPCURL_VERSION=1.8.6
+ARG GRPCURL_VERSION=1.8.7
 RUN curl -fsSL -o grpcurl.tar.gz "https://github.com/fullstorydev/grpcurl/archive/v${GRPCURL_VERSION}.tar.gz" \
     && tar -x -z --strip-components 1 -f grpcurl.tar.gz \
     && rm -f grpcurl.tar.gz \

--- a/18.04/ubuntu-dev/Dockerfile
+++ b/18.04/ubuntu-dev/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG HUB_VERSION=2.14.2
-ARG GH_VERSION=1.9.1
+ARG GH_VERSION=2.14.3
 RUN curl -fsL -o /tmp/hub.tgz https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz \
     && tar -C /tmp -xzf /tmp/hub.tgz \
     && /tmp/hub-linux-amd64-${HUB_VERSION}/install \
@@ -20,6 +20,5 @@ RUN curl -fsL -o /tmp/hub.tgz https://github.com/github/hub/releases/download/v$
     && curl -o /tmp/gh.deb -fsL https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
-
 
 CMD ["/bin/bash"]

--- a/18.04/ubuntu/Dockerfile
+++ b/18.04/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG_MINIMAL
 
-FROM k8s.gcr.io/pause:3.2
+FROM k8s.gcr.io/pause:3.6
 
 FROM quay.io/cybozu/ubuntu-minimal:${TAG_MINIMAL}
 

--- a/20.04/ubuntu-debug/Dockerfile
+++ b/20.04/ubuntu-debug/Dockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/cybozu/golang:1.17-focal AS builder
+FROM quay.io/cybozu/golang:1.18-focal AS builder
 
 WORKDIR /go/src/github.com/fullstorydev/grpcurl
-ARG GRPCURL_VERSION=1.8.6
+ARG GRPCURL_VERSION=1.8.7
 RUN curl -fsSL -o grpcurl.tar.gz "https://github.com/fullstorydev/grpcurl/archive/v${GRPCURL_VERSION}.tar.gz" \
     && tar -x -z --strip-components 1 -f grpcurl.tar.gz \
     && rm -f grpcurl.tar.gz \

--- a/20.04/ubuntu-dev/Dockerfile
+++ b/20.04/ubuntu-dev/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG HUB_VERSION=2.14.2
-ARG GH_VERSION=1.9.1
+ARG GH_VERSION=2.14.3
 RUN curl -fsL -o /tmp/hub.tgz https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz \
     && tar -C /tmp -xzf /tmp/hub.tgz \
     && /tmp/hub-linux-amd64-${HUB_VERSION}/install \

--- a/20.04/ubuntu/Dockerfile
+++ b/20.04/ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG TAG_MINIMAL
 
-FROM k8s.gcr.io/pause:3.2
+FROM k8s.gcr.io/pause:3.6
 
 FROM quay.io/cybozu/ubuntu-minimal:${TAG_MINIMAL}
 


### PR DESCRIPTION
* pause from 3.2 to 3.6
* gRPCurl from 1.8.6 to 1.8.7
* gh (GitHub CLI) from 1.9.1 to 2.14.3
* Go in builder container from 1.17 to 1.18

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>