### PR TITLE
Fix docker buildx version to v0.9.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,6 +24,8 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          version: v0.9.1
       - name: Login to container registry
         if: github.event_name != 'pull_request'
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io


### PR DESCRIPTION
Docker buildx creates a manifest that has changed spec since v0.10.0 so it is not possible to check if the tag already exists.
I fix docker buildx version to v0.9.1.
Signed-off-by: zeroalphat <taichi-takemura@cybozu.co.jp>