### PR TITLE
Add daily-usn on `trivy` branch

### DIFF
--- a/daily-usn/.gitignore
+++ b/daily-usn/.gitignore
@@ -1,0 +1,27 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+daily-usn
+
+dist/
+trivy-result/
+trivy-result-old/

--- a/daily-usn/README.md
+++ b/daily-usn/README.md
@@ -1,0 +1,1 @@
+# daily-usn

--- a/daily-usn/go.mod
+++ b/daily-usn/go.mod
@@ -1,0 +1,3 @@
+module github.com/ushitora-anqou/daily-usn
+
+go 1.20

--- a/daily-usn/go.mod
+++ b/daily-usn/go.mod
@@ -1,3 +1,3 @@
-module github.com/ushitora-anqou/daily-usn
+module github.com/cybozu/ubuntu-base/daily-usn
 
 go 1.20

--- a/daily-usn/main.go
+++ b/daily-usn/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -348,7 +347,7 @@ func generateReportEntries(trivyResultOldDir string, trivyResultDir string) ([]R
 			oldVuls = oldResults.Results[0].Vulnerabilities
 		}
 		diffTrivyVuls := diffTrivyVulnerabilities(oldVuls, newResults.Results[0].Vulnerabilities)
-		rawTrivyJSON, err := ioutil.ReadFile(newFilePath)
+		rawTrivyJSON, err := os.ReadFile(newFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/daily-usn/main.go
+++ b/daily-usn/main.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"text/template"
+)
+
+type TrivyJSONResultVulnerability struct {
+	VulnerabilityID  string
+	PkgID            string
+	PkgName          string
+	InstalledVersion string
+	FixedVersion     string
+	Layer            map[string]string
+	SeveritySource   string
+	PrimaryURL       string
+	DataSource       map[string]string
+	Title            string
+	Description      string
+	Severity         string
+	CweIDs           []string
+	CVSS             map[string]interface{}
+	References       []string
+	PublishedDate    string
+	LastModifiedData string
+}
+
+type TrivyJSONResult struct {
+	Vulnerabilities []TrivyJSONResultVulnerability
+}
+
+type TrivyJSON struct {
+	SchemaVersion int
+	ArtifactName  string
+	Results       []TrivyJSONResult
+}
+
+type Vulnerability struct {
+	PkgID            string
+	PkgName          string
+	InstalledVersion string
+	FixedVersion     string
+	ID               string
+	USN              string
+	PrimaryUrl       string
+	USNUrl           string
+	Title            string
+	Description      string
+	Severity         string
+}
+
+type ReportEntry struct {
+	ArtifactName string
+	DiffVuls     []*Vulnerability
+	AllVuls      []*Vulnerability
+	RawTrivyJSON string
+}
+
+func fetchUSNFromCVE(cveId string) (string, error) {
+	url, err := url.JoinPath("https://ubuntu.com/security/cves/", cveId+".json")
+	if err != nil {
+		return "", err
+	}
+	log.Printf("GET %s\n", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	dec := json.NewDecoder(resp.Body)
+	body := map[string]interface{}{}
+	if err := dec.Decode(&body); err != nil {
+		return "", err
+	}
+	notices, ok := body["notices"].([]interface{})
+	if !ok {
+		return "", errors.New("Invalid JSON")
+	}
+	usn := ""
+	for _, rawNotice := range notices {
+		notice := rawNotice.(map[string]interface{})
+
+		typ, ok := notice["type"].(string)
+		if !ok || typ != "USN" {
+			continue
+		}
+		usn, ok = notice["id"].(string)
+		if !ok {
+			continue
+		}
+		break
+	}
+	if usn == "" {
+		return "", errors.New("USN not found")
+	}
+	return usn, nil
+}
+
+func NewVulnerability(j *TrivyJSONResultVulnerability) *Vulnerability {
+	id := j.VulnerabilityID
+	usnId, err := fetchUSNFromCVE(id)
+	if err != nil {
+		log.Printf("Couldn't fetch USN from CVE: %s: %v", id, err)
+	}
+	usnLink := ""
+	if usnId != "" {
+		usnLink = path.Join("https://ubuntu.com/security/notices/", usnId)
+	}
+
+	return &Vulnerability{
+		PkgID:            j.PkgID,
+		PkgName:          j.PkgName,
+		InstalledVersion: j.InstalledVersion,
+		FixedVersion:     j.FixedVersion,
+		ID:               id,
+		USN:              usnId,
+		PrimaryUrl:       j.PrimaryURL,
+		USNUrl:           usnLink,
+		Title:            j.Title,
+		Description:      j.Description,
+		Severity:         j.Severity,
+	}
+}
+
+func parseTrivyJSON(reader io.Reader) (*TrivyJSON, error) {
+	dec := json.NewDecoder(reader)
+	var res TrivyJSON
+	if err := dec.Decode(&res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func diffVulnerabilities(oldVuls []*Vulnerability, newVuls []*Vulnerability) []*Vulnerability {
+	m := map[string]*Vulnerability{}
+	for _, v := range oldVuls {
+		m[v.ID+v.PkgID] = v
+	}
+
+	res := []*Vulnerability{}
+	for _, v := range newVuls {
+		_, ok := m[v.ID+v.PkgID]
+		if !ok {
+			res = append(res, v)
+		}
+	}
+
+	return res
+}
+
+func diffTrivyVulnerabilities(oldVuls []TrivyJSONResultVulnerability, newVuls []TrivyJSONResultVulnerability) []TrivyJSONResultVulnerability {
+	m := map[string]TrivyJSONResultVulnerability{}
+	for _, v := range oldVuls {
+		m[v.VulnerabilityID+v.PkgID] = v
+	}
+
+	res := []TrivyJSONResultVulnerability{}
+	for _, v := range newVuls {
+		_, ok := m[v.VulnerabilityID+v.PkgID]
+		if !ok {
+			res = append(res, v)
+		}
+	}
+
+	return res
+}
+
+func loadTrivyJSON(fileName string) (*TrivyJSON, error) {
+	file, err := os.Open(fileName)
+	if err != nil {
+		log.Printf("Couldn't open file (%s, %s). Treated as no results.", fileName, err)
+		return nil, nil
+	}
+	defer file.Close()
+
+	j, err := parseTrivyJSON(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(j.Results) != 1 {
+		return nil, fmt.Errorf("Invalid # of JSON results: %d", len(j.Results))
+	}
+
+	return j, nil
+}
+
+func ConvertTrivyVulsToVuls(trivyVuls []TrivyJSONResultVulnerability) []*Vulnerability {
+	vuls := []*Vulnerability{}
+	for _, trivyVul := range trivyVuls {
+		vul := NewVulnerability(&trivyVul)
+		vuls = append(vuls, vul)
+	}
+	return vuls
+}
+
+func generateHTML(reportId string, entries []ReportEntry) (string, error) {
+	const tpl = `
+{{ define "vultable" }}
+<table>
+<thead>
+    <tr>
+        <th>Package Name</th>
+        <th>Vulnerability ID</th>
+        <th>USN ID</th>
+        <th>Severity</th>
+        <th>Installed Version </th>
+        <th>Fixed Version</th>
+        <th>Title</th>
+    </tr>
+</thead>
+<tbody>
+{{ range . }}
+<tr class="severity-{{ .Severity }}">
+    <td>{{ .PkgName }}</td>
+    <td><a href="{{ .PrimaryUrl }}">{{ .ID }}</a></td>
+    <td><a href="{{ .USNUrl }}">{{ .USN }}</a></td>
+    <td>{{ .Severity }}</td>
+    <td>{{ .InstalledVersion }}</td>
+    <td>{{ .FixedVersion }}</td>
+    <td>{{ .Title }}</td>
+</tr>
+{{ end }}
+</tbody>
+</table>
+{{ end }}
+{{/* ======================== */}}
+<html>
+<head>
+<title>daily-usn</title>
+<style>
+{{/* Thanks to: https://github.com/aquasecurity/trivy/blob/72e302cf818cbb2c983c64a3929778b0b25ccb1d/contrib/html.tpl */}}
+* {
+    font-family: Arial, Helvetica, sans-serif;
+}
+h1, h2, h3 {
+    text-align: center;
+}
+.group-header th {
+    font-size: 200%;
+}
+.sub-header th {
+    font-size: 150%;
+}
+table, th, td {
+    border: 1px solid black;
+    border-collapse: collapse;
+    white-space: nowrap;
+    padding: .3em;
+}
+table {
+    margin: 0 auto;
+}
+.severity {
+    text-align: center;
+    font-weight: bold;
+    color: #fafafa;
+}
+.severity-LOW .severity { background-color: #5fbb31; }
+.severity-MEDIUM .severity { background-color: #e9c600; }
+.severity-HIGH .severity { background-color: #ff8800; }
+.severity-CRITICAL .severity { background-color: #e40000; }
+.severity-UNKNOWN .severity { background-color: #747474; }
+.severity-LOW { background-color: #5fbb3160; }
+.severity-MEDIUM { background-color: #e9c60060; }
+.severity-HIGH { background-color: #ff880060; }
+.severity-CRITICAL { background-color: #e4000060; }
+.severity-UNKNOWN { background-color: #74747460; }
+table tr td:first-of-type {
+    font-weight: bold;
+}
+</style>
+</head>
+<body>
+<h1>Daily Vulnerability Report ({{ .ReportId }})</h1>
+{{/* ======================== */}}
+{{ range .Entries }}
+<h2>{{ .ArtifactName }}</h2>
+<h3>New vulnerabilities appeared in this run</h3>
+{{ template "vultable" .DiffVuls }}
+<h3>All vulnerabilities found by Trivy</h3>
+<center>
+<details>
+<summary>Click here to unfold</summary>
+{{ template "vultable" .AllVuls }}
+</details>
+</center>
+{{ end }}
+{{/* ======================== */}}
+</body>
+</html>
+`
+
+	t, err := template.New("webpage").Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+	data := struct {
+		ReportId string
+		Entries  []ReportEntry
+	}{
+		ReportId: reportId,
+		Entries:  entries,
+	}
+	b := bytes.Buffer{}
+	if err := t.Execute(&b, data); err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}
+
+func generateReportEntries(trivyResultOldDir string, trivyResultDir string) ([]ReportEntry, error) {
+	newFiles, err := os.ReadDir(trivyResultDir)
+	if err != nil {
+		return nil, err
+	}
+
+	reportEntries := []ReportEntry{}
+	for _, file := range newFiles {
+		fileName := file.Name()
+
+		newFilePath := filepath.Join(trivyResultDir, fileName)
+		oldFilePath := filepath.Join(trivyResultOldDir, fileName)
+		log.Printf("new_file_path = %s\n", newFilePath)
+		log.Printf("old_file_path = %s\n", oldFilePath)
+
+		newResults, err := loadTrivyJSON(newFilePath)
+		if err != nil {
+			return nil, err
+		}
+		oldResults, err := loadTrivyJSON(oldFilePath)
+		if err != nil {
+			return nil, err
+		}
+		oldVuls := []TrivyJSONResultVulnerability{}
+		if oldResults != nil {
+			oldVuls = oldResults.Results[0].Vulnerabilities
+		}
+		diffTrivyVuls := diffTrivyVulnerabilities(oldVuls, newResults.Results[0].Vulnerabilities)
+		rawTrivyJSON, err := ioutil.ReadFile(newFilePath)
+		if err != nil {
+			return nil, err
+		}
+
+		reportEntry := ReportEntry{
+			ArtifactName: newResults.ArtifactName,
+			AllVuls:      ConvertTrivyVulsToVuls(newResults.Results[0].Vulnerabilities),
+			DiffVuls:     ConvertTrivyVulsToVuls(diffTrivyVuls),
+			RawTrivyJSON: string(rawTrivyJSON),
+		}
+		reportEntries = append(reportEntries, reportEntry)
+	}
+
+	return reportEntries, nil
+}
+
+func process(reportId string, trivyResultOldDir string, trivyResultDir string) error {
+	reportEntries, err := generateReportEntries(trivyResultOldDir, trivyResultDir)
+	if err != nil {
+		return err
+	}
+	html, err := generateHTML(reportId, reportEntries)
+	if err != nil {
+		return err
+	}
+	fmt.Print(html)
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		log.Fatal("Usage: daily-usn REPORT-ID OLD-RESULT-DIR NEW-RESULT-DIR")
+	}
+	err := process(os.Args[1], os.Args[2], os.Args[3])
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/daily-usn/main_test.go
+++ b/daily-usn/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestProcess(t *testing.T) {
+	result, err := generateReportEntries("test/01-old", "test/01-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != 3 {
+		t.Fatal("Invalid length of the result")
+	}
+	if result[0].ArtifactName != "quay.io/cybozu/ubuntu:18.04.20230427" ||
+		result[1].ArtifactName != "quay.io/cybozu/ubuntu:20.04.20230427" ||
+		result[2].ArtifactName != "quay.io/cybozu/ubuntu:22.04.20230427" {
+		t.Fatal("Invalid ArtifactName")
+	}
+	if len(result[0].AllVuls) != 1 || len(result[0].DiffVuls) != 1 ||
+		len(result[1].AllVuls) != 1 || len(result[1].DiffVuls) != 1 ||
+		len(result[2].AllVuls) != 1 || len(result[2].DiffVuls) != 1 {
+		t.Fatal("Invalid length of AllVuls and/or DiffVuls")
+	}
+}

--- a/daily-usn/test/01-new/18.04.20230427.json
+++ b/daily-usn/test/01-new/18.04.20230427.json
@@ -1,0 +1,162 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "quay.io/cybozu/ubuntu:18.04.20230427",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "ubuntu",
+      "Name": "18.04"
+    },
+    "ImageID": "sha256:93fcd3cd9ccc6b18396970d8ae1582e2eebc85477b7ae75a4bda6a5834d892c4",
+    "DiffIDs": [
+      "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4",
+      "sha256:88ce2dbbb73330301ce9308060d18b44a0dad9b61ffa2b7da85c87a9664a1da9",
+      "sha256:5d0f339be5e4644ccbbbad77916e567e8e48e0d0cf4c97a1faf4179dc8d5c1c7",
+      "sha256:f1c34742a7bcc74ece70c2d635acd8429b8a5caee2acdf1402861f82a8aef887"
+    ],
+    "RepoTags": [
+      "quay.io/cybozu/ubuntu:18.04.20230427"
+    ],
+    "RepoDigests": [
+      "quay.io/cybozu/ubuntu@sha256:7ea768efa5afa15f185bb1b6b3c0ed7762c246531a0cd1a58aaa8d835986bd12"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2023-04-27T02:41:28.977162251Z",
+      "history": [
+        {
+          "created": "2023-03-08T03:22:42.455864719Z",
+          "created_by": "/bin/sh -c #(nop)  ARG RELEASE",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.517845487Z",
+          "created_by": "/bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.579821915Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.ref.name=ubuntu",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.646372194Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.version=18.04",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:44.482610627Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:4560926e076acae6b8396a9f1e760eee0f53e22e90ce8554dda57f1103547795 in / "
+        },
+        {
+          "created": "2023-03-08T03:22:44.73196058Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-27T02:41:27.713960061Z",
+          "created_by": "RUN /bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         locales         tzdata         openssl         netbase         apt-utils         apt-transport-https         libreadline7         ca-certificates         curl     && apt-get -y upgrade     && rm -rf /var/lib/apt/lists/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.953416616Z",
+          "created_by": "RUN /bin/sh -c locale-gen en_US.UTF-8     && update-locale LANG=en_US.UTF-8     && echo \"Etc/UTC\" > /etc/timezone     && dpkg-reconfigure -f noninteractive tzdata # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.977162251Z",
+          "created_by": "COPY /pause /usr/local/bin/pause # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.977162251Z",
+          "created_by": "CMD [\"/bin/bash\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4",
+          "sha256:88ce2dbbb73330301ce9308060d18b44a0dad9b61ffa2b7da85c87a9664a1da9",
+          "sha256:5d0f339be5e4644ccbbbad77916e567e8e48e0d0cf4c97a1faf4179dc8d5c1c7",
+          "sha256:f1c34742a7bcc74ece70c2d635acd8429b8a5caee2acdf1402861f82a8aef887"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/bash"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Labels": {
+          "org.opencontainers.image.ref.name": "ubuntu",
+          "org.opencontainers.image.version": "18.04"
+        },
+        "ArgsEscaped": true
+      }
+    }
+  },
+  "Results": [
+    {
+      "Target": "quay.io/cybozu/ubuntu:18.04.20230427 (ubuntu 18.04)",
+      "Class": "os-pkgs",
+      "Type": "ubuntu",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2016-2781",
+          "PkgID": "coreutils@8.28-1ubuntu1",
+          "PkgName": "coreutils",
+          "InstalledVersion": "8.28-1ubuntu1",
+          "Layer": {
+            "Digest": "sha256:0c5227665c11379f79e9da3d3e4f1724f9316b87d259ac0131628ca1b923a392",
+            "DiffID": "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4"
+          },
+          "SeveritySource": "ubuntu",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2016-2781",
+          "DataSource": {
+            "ID": "ubuntu",
+            "Name": "Ubuntu CVE Tracker",
+            "URL": "https://git.launchpad.net/ubuntu-cve-tracker"
+          },
+          "Title": "coreutils: Non-privileged session can escape to the parent session in chroot",
+          "Description": "chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-20"
+          ],
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
+              "V2Score": 2.1,
+              "V3Score": 6.5
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+              "V2Score": 6.2,
+              "V3Score": 8.6
+            }
+          },
+          "References": [
+            "http://seclists.org/oss-sec/2016/q1/452",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/2",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/3",
+            "https://access.redhat.com/security/cve/CVE-2016-2781",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2781",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E",
+            "https://lore.kernel.org/patchwork/patch/793178/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-2781",
+            "https://www.cve.org/CVERecord?id=CVE-2016-2781"
+          ],
+          "PublishedDate": "2017-02-07T15:59:00Z",
+          "LastModifiedDate": "2021-02-25T17:15:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/daily-usn/test/01-new/20.04.20230427.json
+++ b/daily-usn/test/01-new/20.04.20230427.json
@@ -1,0 +1,162 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "quay.io/cybozu/ubuntu:20.04.20230427",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "ubuntu",
+      "Name": "20.04"
+    },
+    "ImageID": "sha256:666de18f7f6ebcd92a64be43ebad1b7d2f71cc406961a58bd673735275bde581",
+    "DiffIDs": [
+      "sha256:6f37ca73c74f2cef0ddefd960260f2033c16c84583c5507a4f37b1cf7631dc20",
+      "sha256:454b0c31b34e72708ab0857abcb2fecdcf4f15653ae97ba6e649415f93827d93",
+      "sha256:c4cd44bdc801ee454c5074fb6cdee59fa51408991d3defd6833742278c00ba44",
+      "sha256:b909a18fec0ac7a5682528af6e87e6f661417e2417fc88066823b7ffa6e57ed3"
+    ],
+    "RepoTags": [
+      "quay.io/cybozu/ubuntu:20.04.20230427"
+    ],
+    "RepoDigests": [
+      "quay.io/cybozu/ubuntu@sha256:2ad7ff198e8a00acd68485356baaaf30020d0541a079a01fa2c6badc59bcf2db"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2023-04-27T02:41:15.121639933Z",
+      "history": [
+        {
+          "created": "2023-04-13T13:05:13.496726073Z",
+          "created_by": "/bin/sh -c #(nop)  ARG RELEASE",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-13T13:05:13.557712287Z",
+          "created_by": "/bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-13T13:05:13.637326115Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.ref.name=ubuntu",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-13T13:05:13.704319522Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.version=20.04",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-13T13:05:15.451478418Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:d05d1c0936b046937bd5755876db2f8da3ed8ccbcf464bb56c312fbc7ed78589 in / "
+        },
+        {
+          "created": "2023-04-13T13:05:15.714908196Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-27T02:41:13.144354999Z",
+          "created_by": "RUN /bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         locales         tzdata         openssl         netbase         apt-utils         apt-transport-https         libreadline8         ca-certificates         curl     && apt-get -y upgrade     && rm -rf /var/lib/apt/lists/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:15.097889472Z",
+          "created_by": "RUN /bin/sh -c locale-gen en_US.UTF-8     && update-locale LANG=en_US.UTF-8     && echo \"Etc/UTC\" > /etc/timezone     && dpkg-reconfigure -f noninteractive tzdata # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:15.121639933Z",
+          "created_by": "COPY /pause /usr/local/bin/pause # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:15.121639933Z",
+          "created_by": "CMD [\"/bin/bash\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:6f37ca73c74f2cef0ddefd960260f2033c16c84583c5507a4f37b1cf7631dc20",
+          "sha256:454b0c31b34e72708ab0857abcb2fecdcf4f15653ae97ba6e649415f93827d93",
+          "sha256:c4cd44bdc801ee454c5074fb6cdee59fa51408991d3defd6833742278c00ba44",
+          "sha256:b909a18fec0ac7a5682528af6e87e6f661417e2417fc88066823b7ffa6e57ed3"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/bash"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Labels": {
+          "org.opencontainers.image.ref.name": "ubuntu",
+          "org.opencontainers.image.version": "20.04"
+        },
+        "ArgsEscaped": true
+      }
+    }
+  },
+  "Results": [
+    {
+      "Target": "quay.io/cybozu/ubuntu:20.04.20230427 (ubuntu 20.04)",
+      "Class": "os-pkgs",
+      "Type": "ubuntu",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2016-2781",
+          "PkgID": "coreutils@8.30-3ubuntu2",
+          "PkgName": "coreutils",
+          "InstalledVersion": "8.30-3ubuntu2",
+          "Layer": {
+            "Digest": "sha256:ca1778b6935686ad781c27472c4668fc61ec3aeb85494f72deb1921892b9d39e",
+            "DiffID": "sha256:6f37ca73c74f2cef0ddefd960260f2033c16c84583c5507a4f37b1cf7631dc20"
+          },
+          "SeveritySource": "ubuntu",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2016-2781",
+          "DataSource": {
+            "ID": "ubuntu",
+            "Name": "Ubuntu CVE Tracker",
+            "URL": "https://git.launchpad.net/ubuntu-cve-tracker"
+          },
+          "Title": "coreutils: Non-privileged session can escape to the parent session in chroot",
+          "Description": "chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-20"
+          ],
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
+              "V2Score": 2.1,
+              "V3Score": 6.5
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+              "V2Score": 6.2,
+              "V3Score": 8.6
+            }
+          },
+          "References": [
+            "http://seclists.org/oss-sec/2016/q1/452",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/2",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/3",
+            "https://access.redhat.com/security/cve/CVE-2016-2781",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2781",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E",
+            "https://lore.kernel.org/patchwork/patch/793178/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-2781",
+            "https://www.cve.org/CVERecord?id=CVE-2016-2781"
+          ],
+          "PublishedDate": "2017-02-07T15:59:00Z",
+          "LastModifiedDate": "2021-02-25T17:15:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/daily-usn/test/01-new/22.04.20230427.json
+++ b/daily-usn/test/01-new/22.04.20230427.json
@@ -1,0 +1,161 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "quay.io/cybozu/ubuntu:22.04.20230427",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "ubuntu",
+      "Name": "22.04"
+    },
+    "ImageID": "sha256:16af665c208245617ab74a5c59818c6b70620938410637d87cca6060411010aa",
+    "DiffIDs": [
+      "sha256:b93c1bd012ab8fda60f5b4f5906bf244586e0e3292d84571d3abb56472248466",
+      "sha256:e3f4700ecd697feb8363fe7b6c44c7c5e3d478a0494ef275da4f9fc29f0e8fd7",
+      "sha256:c2f33a472412e1604d198c6dda9001a35f0e65f120605219c208433fdb9d7a2b",
+      "sha256:e26231e3b937631da075fac906fd2468c67144edff589792a5691933a378ea58"
+    ],
+    "RepoTags": [
+      "quay.io/cybozu/ubuntu:22.04.20230427"
+    ],
+    "RepoDigests": [
+      "quay.io/cybozu/ubuntu@sha256:d3eeca4a5cdeabfe187bf9e78ea3d585fb2817342d445c14bf99d9c0b7f9487d"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2023-04-27T02:41:11.824499762Z",
+      "history": [
+        {
+          "created": "2023-03-08T04:44:25.225589475Z",
+          "created_by": "/bin/sh -c #(nop)  ARG RELEASE",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T04:44:25.380763616Z",
+          "created_by": "/bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T04:44:25.43565156Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.ref.name=ubuntu",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T04:44:25.487233076Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.version=22.04",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T04:44:27.440479984Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:c8ef6447752cab2541ffca9e3cfa27d581f3491bc8f356f6eafd951243609341 in / "
+        },
+        {
+          "created": "2023-03-08T04:44:27.714921351Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-27T02:41:09.841315182Z",
+          "created_by": "RUN /bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         locales         tzdata         openssl         netbase         apt-utils         apt-transport-https         libreadline8         ca-certificates         curl     && apt-get -y upgrade     && rm -rf /var/lib/apt/lists/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:11.812236921Z",
+          "created_by": "RUN /bin/sh -c locale-gen en_US.UTF-8     && update-locale LANG=en_US.UTF-8     && echo \"Etc/UTC\" > /etc/timezone     && dpkg-reconfigure -f noninteractive tzdata # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:11.824499762Z",
+          "created_by": "COPY /pause /usr/local/bin/pause # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:11.824499762Z",
+          "created_by": "CMD [\"/bin/bash\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:b93c1bd012ab8fda60f5b4f5906bf244586e0e3292d84571d3abb56472248466",
+          "sha256:e3f4700ecd697feb8363fe7b6c44c7c5e3d478a0494ef275da4f9fc29f0e8fd7",
+          "sha256:c2f33a472412e1604d198c6dda9001a35f0e65f120605219c208433fdb9d7a2b",
+          "sha256:e26231e3b937631da075fac906fd2468c67144edff589792a5691933a378ea58"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/bash"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Labels": {
+          "org.opencontainers.image.ref.name": "ubuntu",
+          "org.opencontainers.image.version": "22.04"
+        },
+        "ArgsEscaped": true
+      }
+    }
+  },
+  "Results": [
+    {
+      "Target": "quay.io/cybozu/ubuntu:22.04.20230427 (ubuntu 22.04)",
+      "Class": "os-pkgs",
+      "Type": "ubuntu",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2022-3715",
+          "PkgID": "bash@5.1-6ubuntu1",
+          "PkgName": "bash",
+          "InstalledVersion": "5.1-6ubuntu1",
+          "Layer": {
+            "Digest": "sha256:2ab09b027e7f3a0c2e8bb1944ac46de38cebab7145f0bd6effebfe5492c818b6",
+            "DiffID": "sha256:b93c1bd012ab8fda60f5b4f5906bf244586e0e3292d84571d3abb56472248466"
+          },
+          "SeveritySource": "ubuntu",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2022-3715",
+          "DataSource": {
+            "ID": "ubuntu",
+            "Name": "Ubuntu CVE Tracker",
+            "URL": "https://git.launchpad.net/ubuntu-cve-tracker"
+          },
+          "Title": "a heap-buffer-overflow in valid_parameter_transform",
+          "Description": "A flaw was found in the bash package, where a heap-buffer overflow can occur in valid parameter_transform. This issue may lead to memory problems.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-787"
+          ],
+          "CVSS": {
+            "nvd": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+              "V3Score": 7.8
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:H",
+              "V3Score": 6.6
+            }
+          },
+          "References": [
+            "https://access.redhat.com/errata/RHSA-2023:0340",
+            "https://access.redhat.com/security/cve/CVE-2022-3715",
+            "https://bugzilla.redhat.com/2126720",
+            "https://bugzilla.redhat.com/show_bug.cgi?id=2126720",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3715",
+            "https://errata.almalinux.org/9/ALSA-2023-0340.html",
+            "https://errata.rockylinux.org/RLSA-2023:0340",
+            "https://linux.oracle.com/cve/CVE-2022-3715.html",
+            "https://linux.oracle.com/errata/ELSA-2023-0340.html",
+            "https://lists.gnu.org/archive/html/bug-bash/2022-08/msg00147.html",
+            "https://nvd.nist.gov/vuln/detail/CVE-2022-3715",
+            "https://www.cve.org/CVERecord?id=CVE-2022-3715"
+          ],
+          "PublishedDate": "2023-01-05T15:15:00Z",
+          "LastModifiedDate": "2023-02-24T18:38:00Z"
+        }
+      ]
+    }
+  ]
+}

--- a/daily-usn/test/01-old/18.04.20230427.json
+++ b/daily-usn/test/01-old/18.04.20230427.json
@@ -1,0 +1,111 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "quay.io/cybozu/ubuntu:18.04.20230427",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "ubuntu",
+      "Name": "18.04"
+    },
+    "ImageID": "sha256:93fcd3cd9ccc6b18396970d8ae1582e2eebc85477b7ae75a4bda6a5834d892c4",
+    "DiffIDs": [
+      "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4",
+      "sha256:88ce2dbbb73330301ce9308060d18b44a0dad9b61ffa2b7da85c87a9664a1da9",
+      "sha256:5d0f339be5e4644ccbbbad77916e567e8e48e0d0cf4c97a1faf4179dc8d5c1c7",
+      "sha256:f1c34742a7bcc74ece70c2d635acd8429b8a5caee2acdf1402861f82a8aef887"
+    ],
+    "RepoTags": [
+      "quay.io/cybozu/ubuntu:18.04.20230427"
+    ],
+    "RepoDigests": [
+      "quay.io/cybozu/ubuntu@sha256:7ea768efa5afa15f185bb1b6b3c0ed7762c246531a0cd1a58aaa8d835986bd12"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "created": "2023-04-27T02:41:28.977162251Z",
+      "history": [
+        {
+          "created": "2023-03-08T03:22:42.455864719Z",
+          "created_by": "/bin/sh -c #(nop)  ARG RELEASE",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.517845487Z",
+          "created_by": "/bin/sh -c #(nop)  ARG LAUNCHPAD_BUILD_ARCH",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.579821915Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.ref.name=ubuntu",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:42.646372194Z",
+          "created_by": "/bin/sh -c #(nop)  LABEL org.opencontainers.image.version=18.04",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-03-08T03:22:44.482610627Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:4560926e076acae6b8396a9f1e760eee0f53e22e90ce8554dda57f1103547795 in / "
+        },
+        {
+          "created": "2023-03-08T03:22:44.73196058Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/bash\"]",
+          "empty_layer": true
+        },
+        {
+          "created": "2023-04-27T02:41:27.713960061Z",
+          "created_by": "RUN /bin/sh -c apt-get update     && apt-get install -y --no-install-recommends         locales         tzdata         openssl         netbase         apt-utils         apt-transport-https         libreadline7         ca-certificates         curl     && apt-get -y upgrade     && rm -rf /var/lib/apt/lists/* # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.953416616Z",
+          "created_by": "RUN /bin/sh -c locale-gen en_US.UTF-8     && update-locale LANG=en_US.UTF-8     && echo \"Etc/UTC\" > /etc/timezone     && dpkg-reconfigure -f noninteractive tzdata # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.977162251Z",
+          "created_by": "COPY /pause /usr/local/bin/pause # buildkit",
+          "comment": "buildkit.dockerfile.v0"
+        },
+        {
+          "created": "2023-04-27T02:41:28.977162251Z",
+          "created_by": "CMD [\"/bin/bash\"]",
+          "comment": "buildkit.dockerfile.v0",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4",
+          "sha256:88ce2dbbb73330301ce9308060d18b44a0dad9b61ffa2b7da85c87a9664a1da9",
+          "sha256:5d0f339be5e4644ccbbbad77916e567e8e48e0d0cf4c97a1faf4179dc8d5c1c7",
+          "sha256:f1c34742a7bcc74ece70c2d635acd8429b8a5caee2acdf1402861f82a8aef887"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/bash"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Labels": {
+          "org.opencontainers.image.ref.name": "ubuntu",
+          "org.opencontainers.image.version": "18.04"
+        },
+        "ArgsEscaped": true
+      }
+    }
+  },
+  "Results": [
+    {
+      "Target": "quay.io/cybozu/ubuntu:18.04.20230427 (ubuntu 18.04)",
+      "Class": "os-pkgs",
+      "Type": "ubuntu",
+      "Vulnerabilities": []
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds [daily-usn](https://github.com/ushitora-anqou/daily-usn) to `trivy` branch. This program takes two directories including results of Trivy as command-line arguments, compares them, and generates an HTML file summarizing the vulnerability information contained in those results. This PR is intended to work with `.github/workflows/verify.yaml` on `main` branch, which should be added by my earlier PR.