### PR TITLE
Add `workflow_dispatch:` to verify.yaml

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,5 +1,6 @@
 name: verify
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1-5' # At 00:00 on every day-of-week from Monday through Friday (UTC) (crontab.guru)
 


### PR DESCRIPTION
This PR adds `workflow_dispatch:` to `on:` field of `.github/workflows/verify.yaml` so that we can run this action manually.