### PR TITLE
Fix links generated by daily-usn

### DIFF
--- a/daily-usn/main.go
+++ b/daily-usn/main.go
@@ -223,8 +223,8 @@ func generateHTML(reportId string, entries []ReportEntry) (string, error) {
 {{ range . }}
 <tr class="severity-{{ .Severity }}">
     <td>{{ .PkgName }}</td>
-    <td><a href="{{ .PrimaryUrl }}">{{ .ID }}</a></td>
-    <td><a href="{{ .USNUrl }}">{{ .USN }}</a></td>
+    <td><a href="{{ .PrimaryUrl }}" target="_blank" rel="noopener noreferrer">{{ .ID }}</a></td>
+    <td><a href="{{ .USNUrl }}" target="_blank" rel="noopener noreferrer">{{ .USN }}</a></td>
     <td>{{ .Severity }}</td>
     <td>{{ .InstalledVersion }}</td>
     <td>{{ .FixedVersion }}</td>

--- a/daily-usn/main.go
+++ b/daily-usn/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"text/template"
 )
@@ -113,7 +112,7 @@ func NewVulnerability(j *TrivyJSONResultVulnerability) *Vulnerability {
 	}
 	usnLink := ""
 	if usnId != "" {
-		usnLink = path.Join("https://ubuntu.com/security/notices/", usnId)
+		usnLink = "https://ubuntu.com/security/notices/" + usnId
 	}
 
 	return &Vulnerability{

--- a/daily-usn/main.go
+++ b/daily-usn/main.go
@@ -106,6 +106,8 @@ func fetchUSNFromCVE(cveId string) (string, error) {
 
 func NewVulnerability(j *TrivyJSONResultVulnerability) *Vulnerability {
 	id := j.VulnerabilityID
+	PrimaryUrl := "https://nvd.nist.gov/vuln/detail/" + id
+
 	usnId, err := fetchUSNFromCVE(id)
 	if err != nil {
 		log.Printf("Couldn't fetch USN from CVE: %s: %v", id, err)
@@ -122,7 +124,7 @@ func NewVulnerability(j *TrivyJSONResultVulnerability) *Vulnerability {
 		FixedVersion:     j.FixedVersion,
 		ID:               id,
 		USN:              usnId,
-		PrimaryUrl:       j.PrimaryURL,
+		PrimaryUrl:       PrimaryUrl,
 		USNUrl:           usnLink,
 		Title:            j.Title,
 		Description:      j.Description,

--- a/daily-usn/main_test.go
+++ b/daily-usn/main_test.go
@@ -15,9 +15,12 @@ func TestProcess(t *testing.T) {
 		result[2].ArtifactName != "quay.io/cybozu/ubuntu:22.04.20230427" {
 		t.Fatal("Invalid ArtifactName")
 	}
-	if len(result[0].AllVuls) != 1 || len(result[0].DiffVuls) != 1 ||
+	if len(result[0].AllVuls) != 2 || len(result[0].DiffVuls) != 1 ||
 		len(result[1].AllVuls) != 1 || len(result[1].DiffVuls) != 1 ||
 		len(result[2].AllVuls) != 1 || len(result[2].DiffVuls) != 1 {
 		t.Fatal("Invalid length of AllVuls and/or DiffVuls")
+	}
+	if result[0].DiffVuls[0].USNUrl != "https://ubuntu.com/security/notices/USN-4954-1" {
+		t.Fatal("Invalid USNUrl")
 	}
 }

--- a/daily-usn/main_test.go
+++ b/daily-usn/main_test.go
@@ -23,4 +23,7 @@ func TestProcess(t *testing.T) {
 	if result[0].DiffVuls[0].USNUrl != "https://ubuntu.com/security/notices/USN-4954-1" {
 		t.Fatal("Invalid USNUrl")
 	}
+	if result[0].DiffVuls[0].PrimaryUrl != "https://nvd.nist.gov/vuln/detail/CVE-2009-5155" {
+		t.Fatalf("Invalid PrimaryUrl: %s", result[0].DiffVuls[0].PrimaryUrl)
+	}
 }

--- a/daily-usn/test/01-new/18.04.20230427.json
+++ b/daily-usn/test/01-new/18.04.20230427.json
@@ -155,6 +155,62 @@
           ],
           "PublishedDate": "2017-02-07T15:59:00Z",
           "LastModifiedDate": "2021-02-25T17:15:00Z"
+        },
+        {
+          "VulnerabilityID": "CVE-2009-5155",
+          "PkgID": "libc-bin@2.27-3ubuntu1.6",
+          "PkgName": "libc-bin",
+          "InstalledVersion": "2.27-3ubuntu1.6",
+          "Layer": {
+            "Digest": "sha256:0c5227665c11379f79e9da3d3e4f1724f9316b87d259ac0131628ca1b923a392",
+            "DiffID": "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4"
+          },
+          "SeveritySource": "ubuntu",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2009-5155",
+          "DataSource": {
+            "ID": "ubuntu",
+            "Name": "Ubuntu CVE Tracker",
+            "URL": "https://git.launchpad.net/ubuntu-cve-tracker"
+          },
+          "Title": "glibc: parse_reg_exp in posix/regcomp.c misparses alternatives leading to denial of service or trigger incorrect result",
+          "Description": "In the GNU C Library (aka glibc or libc6) before 2.28, parse_reg_exp in posix/regcomp.c misparses alternatives, which allows attackers to cause a denial of service (assertion failure and application exit) or trigger an incorrect result by attempting a regular-expression match.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-19"
+          ],
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V2Score": 5,
+              "V3Score": 7.5
+            },
+            "redhat": {
+              "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+              "V3Score": 7.5
+            }
+          },
+          "References": [
+            "http://git.savannah.gnu.org/cgit/gnulib.git/commit/?id=5513b40999149090987a0341c018d05d3eea1272",
+            "https://access.redhat.com/security/cve/CVE-2009-5155",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-5155",
+            "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=22793",
+            "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=32806",
+            "https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34238",
+            "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E",
+            "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E",
+            "https://nvd.nist.gov/vuln/detail/CVE-2009-5155",
+            "https://security.netapp.com/advisory/ntap-20190315-0002/",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=11053",
+            "https://sourceware.org/bugzilla/show_bug.cgi?id=18986",
+            "https://sourceware.org/git/gitweb.cgi?p=glibc.git;h=eb04c21373e2a2885f3d52ff192b0499afe3c672",
+            "https://support.f5.com/csp/article/K64119434",
+            "https://support.f5.com/csp/article/K64119434?utm_source=f5support&amp;utm_medium=RSS",
+            "https://ubuntu.com/security/notices/USN-4954-1",
+            "https://www.cve.org/CVERecord?id=CVE-2009-5155"
+          ],
+          "PublishedDate": "2019-02-26T02:29:00Z",
+          "LastModifiedDate": "2021-06-29T15:15:00Z"
         }
       ]
     }

--- a/daily-usn/test/01-old/18.04.20230427.json
+++ b/daily-usn/test/01-old/18.04.20230427.json
@@ -105,7 +105,58 @@
       "Target": "quay.io/cybozu/ubuntu:18.04.20230427 (ubuntu 18.04)",
       "Class": "os-pkgs",
       "Type": "ubuntu",
-      "Vulnerabilities": []
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2016-2781",
+          "PkgID": "coreutils@8.28-1ubuntu1",
+          "PkgName": "coreutils",
+          "InstalledVersion": "8.28-1ubuntu1",
+          "Layer": {
+            "Digest": "sha256:0c5227665c11379f79e9da3d3e4f1724f9316b87d259ac0131628ca1b923a392",
+            "DiffID": "sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4"
+          },
+          "SeveritySource": "ubuntu",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2016-2781",
+          "DataSource": {
+            "ID": "ubuntu",
+            "Name": "Ubuntu CVE Tracker",
+            "URL": "https://git.launchpad.net/ubuntu-cve-tracker"
+          },
+          "Title": "coreutils: Non-privileged session can escape to the parent session in chroot",
+          "Description": "chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.",
+          "Severity": "LOW",
+          "CweIDs": [
+            "CWE-20"
+          ],
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N",
+              "V2Score": 2.1,
+              "V3Score": 6.5
+            },
+            "redhat": {
+              "V2Vector": "AV:L/AC:H/Au:N/C:C/I:C/A:C",
+              "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+              "V2Score": 6.2,
+              "V3Score": 8.6
+            }
+          },
+          "References": [
+            "http://seclists.org/oss-sec/2016/q1/452",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/2",
+            "http://www.openwall.com/lists/oss-security/2016/02/28/3",
+            "https://access.redhat.com/security/cve/CVE-2016-2781",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2781",
+            "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E",
+            "https://lore.kernel.org/patchwork/patch/793178/",
+            "https://nvd.nist.gov/vuln/detail/CVE-2016-2781",
+            "https://www.cve.org/CVERecord?id=CVE-2016-2781"
+          ],
+          "PublishedDate": "2017-02-07T15:59:00Z",
+          "LastModifiedDate": "2021-02-25T17:15:00Z"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR fixes some issues with links displayed in an HTML file generated by daily-usn.

- Links to the USN page are now rendered correctly.
- CVE IDs are now linked to NVD pages.
- Links now open in a new tab.