### PR TITLE
Update images for 20.04

### DIFF
--- a/20.04/BODY
+++ b/20.04/BODY
@@ -1,0 +1,21 @@
+Update images for 20.04
+- Minimal image updated: focal-20230624
+- ubuntu-debug:20.04: package updated
+```diff
+--- ubuntu-debug-20.04.20230725	2023-07-25 22:04:42.553645107 +0000
++++ ubuntu-debug-20.04-new	2023-07-25 22:04:42.989650413 +0000
+@@ -194,9 +194,9 @@
+ ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ ii  mime-support               3.64ubuntu1                       all          MIME files 'mime.types' & 'mailcap', and support programs
+ ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+-ii  mysql-client               8.0.33-0ubuntu0.20.04.2           all          MySQL database client (metapackage depending on the latest version)
+-ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.2           amd64        MySQL database client binaries
+-ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.2           amd64        MySQL database core client binaries
++ii  mysql-client               8.0.33-0ubuntu0.20.04.4           all          MySQL database client (metapackage depending on the latest version)
++ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.4           amd64        MySQL database client binaries
++ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.4           amd64        MySQL database core client binaries
+ ii  mysql-common               5.8+1.0.5ubuntu2                  all          MySQL database common files, e.g. /etc/mysql/my.cnf
+ ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+```
+

--- a/20.04/ubuntu-20.04-new
+++ b/20.04/ubuntu-20.04-new
@@ -1,0 +1,133 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-========================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime

--- a/20.04/ubuntu-20.04.20230725
+++ b/20.04/ubuntu-20.04.20230725
@@ -1,0 +1,133 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-========================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime

--- a/20.04/ubuntu-debug-20.04-new
+++ b/20.04/ubuntu-debug-20.04-new
@@ -1,0 +1,259 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-===============================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  awscli                     1.18.69-1ubuntu0.20.04.1          all          Universal Command Line Environment for AWS
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  bind9-dnsutils             1:9.16.1-0ubuntu2.15              amd64        Clients provided with BIND 9
+ii  bind9-host                 1:9.16.1-0ubuntu2.15              amd64        DNS Lookup Utility
+ii  bind9-libs:amd64           1:9.16.1-0ubuntu2.15              amd64        Shared Libraries used by BIND 9
+ii  binutils                   2.34-6ubuntu1.6                   amd64        GNU assembler, linker and binary utilities
+ii  binutils-common:amd64      2.34-6ubuntu1.6                   amd64        Common files for the GNU assembler, linker and binary utilities
+ii  binutils-x86-64-linux-gnu  2.34-6ubuntu1.6                   amd64        GNU binary utilities, for x86-64-linux-gnu target
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  docutils-common            0.16+dfsg-2                       all          text processing system for reStructuredText - common data
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  expect                     5.45.4-2build1                    amd64        Automates interactive applications
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  file                       1:5.38-4                          amd64        Recognize the type of data in a file using "magic" numbers
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gdb                        9.2-0ubuntu1~20.04.1              amd64        GNU Debugger
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  groff                      1.22.4-4build1                    amd64        GNU troff text-formatting system
+ii  groff-base                 1.22.4-4build1                    amd64        GNU troff text-formatting system (base system components)
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  iproute2                   5.5.0-1ubuntu1                    amd64        networking and traffic control tools
+ii  iputils-ping               3:20190709-3                      amd64        Tools to test the reachability of network hosts
+ii  jq                         1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor
+ii  less                       551-1ubuntu0.1                    amd64        pager program similar to more
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libasound2:amd64           1.2.2-2.1ubuntu2.5                amd64        shared library for ALSA applications
+ii  libasound2-data            1.2.2-2.1ubuntu2.5                all          Configuration files and profiles for ALSA drivers
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libbabeltrace1:amd64       1.5.8-1build1                     amd64        Babeltrace conversion libraries
+ii  libbinutils:amd64          2.34-6ubuntu1.6                   amd64        GNU binary utilities (private shared library)
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbsd0:amd64              0.10.0-1                          amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libcanberra0:amd64         0.30-7ubuntu1                     amd64        simple abstract interface for playing event sounds
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcap2:amd64              1:2.32-1ubuntu0.1                 amd64        POSIX 1003.1e capabilities (library)
+ii  libcap2-bin                1:2.32-1ubuntu0.1                 amd64        POSIX 1003.1e capabilities (utilities)
+ii  libcbor0.6:amd64           0.6.0-0ubuntu1                    amd64        library for parsing and generating CBOR (RFC 7049)
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libctf-nobfd0:amd64        2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, no BFD dependency)
+ii  libctf0:amd64              2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, BFD dependency)
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libdw1:amd64               0.176-1.1build1                   amd64        library that provides access to the DWARF debug information
+ii  libedit2:amd64             3.1-20191231-1                    amd64        BSD editline and history libraries
+ii  libelf1:amd64              0.176-1.1build1                   amd64        library to read and write ELF files
+ii  libexpat1:amd64            2.2.9-1ubuntu0.6                  amd64        XML parsing C library - runtime library
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libfido2-1:amd64           1.3.1-1ubuntu2                    amd64        library for generating and verifying FIDO 2.0 objects
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libglib2.0-0:amd64         2.64.6-1~ubuntu20.04.6            amd64        GLib library of C routines
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgpm2:amd64              1.20.7-5                          amd64        General Purpose Mouse - shared library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libice6:amd64              2:1.0.10-0ubuntu1                 amd64        X11 Inter-Client Exchange library
+ii  libicu66:amd64             66.1-2ubuntu2.1                   amd64        International Components for Unicode
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libjq1:amd64               1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor - shared library
+ii  libjson-c4:amd64           0.13.1+dfsg-7ubuntu0.3            amd64        JSON manipulation library - shared library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblmdb0:amd64             0.9.24-1                          amd64        Lightning Memory-Mapped Database shared library
+ii  libltdl7:amd64             2.4.6-14                          amd64        System independent dlopen wrapper for GNU libtool
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmagic-mgc               1:5.38-4                          amd64        File type determination library using "magic" numbers (compiled magic file)
+ii  libmagic1:amd64            1:5.38-4                          amd64        Recognize the type of data in a file using "magic" numbers - library
+ii  libmaxminddb0:amd64        1.4.2-0ubuntu1.20.04.1            amd64        IP geolocation database library
+ii  libmnl0:amd64              1.0.4-2                           amd64        minimalistic Netlink communication library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libmpdec2:amd64            2.4.2-3                           amd64        library for decimal floating point arithmetic (runtime library)
+ii  libmpfr6:amd64             4.0.2-1                           amd64        multiple precision floating-point computation
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libogg0:amd64              1.3.4-0ubuntu1                    amd64        Ogg bitstream library
+ii  libonig5:amd64             6.9.4-1                           amd64        regular expressions library
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcap0.8:amd64           1.9.1-3                           amd64        system interface for user-level packet capture
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libpython3-stdlib:amd64    3.8.2-0ubuntu2                    amd64        interactive high-level object-oriented language (default python3 version)
+ii  libpython3.8:amd64         3.8.10-0ubuntu1~20.04.8           amd64        Shared Python runtime library (version 3.8)
+ii  libpython3.8-minimal:amd64 3.8.10-0ubuntu1~20.04.8           amd64        Minimal subset of the Python language (version 3.8)
+ii  libpython3.8-stdlib:amd64  3.8.10-0ubuntu1~20.04.8           amd64        Interactive high-level object-oriented language (standard library, version 3.8)
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsensors-config          1:3.6.0-2ubuntu1.1                all          lm-sensors configuration files
+ii  libsensors5:amd64          1:3.6.0-2ubuntu1.1                amd64        library to read temperature/voltage/fan sensors
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsm6:amd64               2:1.2.3-1                         amd64        X11 Session Management library
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtcl8.6:amd64            8.6.10+dfsg-1                     amd64        Tcl (the Tool Command Language) v8.6 - run-time library files
+ii  libtdb1:amd64              1.4.5-0ubuntu0.20.04.1            amd64        Trivial Database - shared library
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libuchardet0:amd64         0.0.6-3build1                     amd64        universal charset detection library - shared library
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libunwind8:amd64           1.2.1-9ubuntu0.1                  amd64        library to determine the call-chain of a program - runtime
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libuv1:amd64               1.34.2-1ubuntu1.3                 amd64        asynchronous event notification library - runtime library
+ii  libvorbis0a:amd64          1.3.6-2ubuntu1                    amd64        decoder library for Vorbis General Audio Compression Codec
+ii  libvorbisfile3:amd64       1.3.6-2ubuntu1                    amd64        high-level API for Vorbis General Audio Compression Codec
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libx11-6:amd64             2:1.6.9-2ubuntu1.5                amd64        X11 client-side library
+ii  libx11-data                2:1.6.9-2ubuntu1.5                all          X11 client-side library
+ii  libxau6:amd64              1:1.0.9-0ubuntu1                  amd64        X11 authorisation library
+ii  libxaw7:amd64              2:1.0.13-1                        amd64        X11 Athena Widget library
+ii  libxcb1:amd64              1.14-2                            amd64        X C Binding
+ii  libxdmcp6:amd64            1:1.1.3-0ubuntu1                  amd64        X11 Display Manager Control Protocol library
+ii  libxext6:amd64             2:1.3.4-0ubuntu1                  amd64        X11 miscellaneous extension library
+ii  libxml2:amd64              2.9.10+dfsg-5ubuntu0.20.04.6      amd64        GNOME XML library
+ii  libxmu6:amd64              2:1.1.3-0ubuntu1                  amd64        X11 miscellaneous utility library
+ii  libxpm4:amd64              1:3.5.12-1ubuntu0.20.04.1         amd64        X11 pixmap library
+ii  libxt6:amd64               1:1.1.5-1                         amd64        X11 toolkit intrinsics library
+ii  libxtables12:amd64         1.8.4-3ubuntu2.1                  amd64        netfilter xtables library
+ii  libyaml-0-2:amd64          0.2.2-1                           amd64        Fast YAML 1.1 parser and emitter library
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  lv                         4.51-7                            amd64        Powerful Multilingual File Viewer
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mime-support               3.64ubuntu1                       all          MIME files 'mime.types' & 'mailcap', and support programs
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  mysql-client               8.0.33-0ubuntu0.20.04.4           all          MySQL database client (metapackage depending on the latest version)
+ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.4           amd64        MySQL database client binaries
+ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.4           amd64        MySQL database core client binaries
+ii  mysql-common               5.8+1.0.5ubuntu2                  all          MySQL database common files, e.g. /etc/mysql/my.cnf
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  net-tools                  1.60+git20180626.aebd88e-1ubuntu1 amd64        NET-3 networking toolkit
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssh-client             1:8.2p1-4ubuntu0.8                amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  python3                    3.8.2-0ubuntu2                    amd64        interactive high-level object-oriented language (default python3 version)
+ii  python3-botocore           1.16.19+repack-1ubuntu0.20.04.1   all          Low-level, data-driven core of boto 3 (Python 3)
+ii  python3-certifi            2019.11.28-1                      all          root certificates for validating SSL certs and verifying TLS hosts (python3)
+ii  python3-chardet            3.0.4-4build1                     all          universal character encoding detector for Python3
+ii  python3-colorama           0.4.3-1build1                     all          Cross-platform colored terminal text in Python - Python 3.x
+ii  python3-dateutil           2.7.3-3ubuntu1                    all          powerful extensions to the standard Python 3 datetime module
+ii  python3-docutils           0.16+dfsg-2                       all          text processing system for reStructuredText (implemented in Python 3)
+ii  python3-idna               2.8-1                             all          Python IDNA2008 (RFC 5891) handling (Python 3)
+ii  python3-jmespath           0.9.4-2ubuntu1                    all          JSON Matching Expressions (Python 3)
+ii  python3-magic              2:0.4.15-3                        all          python3 interface to the libmagic file type identification library
+ii  python3-minimal            3.8.2-0ubuntu2                    amd64        minimal subset of the Python language (default python3 version)
+ii  python3-pkg-resources      45.2.0-1ubuntu0.1                 all          Package Discovery and Resource Access using pkg_resources
+ii  python3-pyasn1             0.4.2-3build1                     all          ASN.1 library for Python (Python 3 module)
+ii  python3-requests           2.22.0-2ubuntu1.1                 all          elegant and simple HTTP library for Python3, built for human beings
+ii  python3-roman              2.0.0-3build1                     all          module for generating/analyzing Roman numerals for Python 3
+ii  python3-rsa                4.0-3                             all          Pure-Python RSA implementation (Python 3)
+ii  python3-s3transfer         0.3.3-1                           all          Amazon S3 Transfer Manager for Python3
+ii  python3-six                1.14.0-2                          all          Python 2 and 3 compatibility library (Python 3 interface)
+ii  python3-urllib3            1.25.8-2ubuntu0.2                 all          HTTP library with thread-safe connection pooling for Python3
+ii  python3-yaml               5.3.1-1ubuntu0.1                  amd64        YAML parser and emitter for Python3
+ii  python3.8                  3.8.10-0ubuntu1~20.04.8           amd64        Interactive high-level object-oriented language (version 3.8)
+ii  python3.8-minimal          3.8.10-0ubuntu1~20.04.8           amd64        Minimal subset of the Python language (version 3.8)
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  s3cmd                      2.0.2-1ubuntu1                    all          command-line Amazon S3 client
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sgml-base                  1.29.1                            all          SGML infrastructure and SGML catalog file support
+ii  sound-theme-freedesktop    0.8-2ubuntu1                      all          freedesktop.org sound theme
+ii  sqlite3                    3.31.1-4ubuntu0.5                 amd64        Command line interface for SQLite 3
+ii  strace                     5.5-3ubuntu1                      amd64        System call tracer
+ii  sysstat                    12.2.0-2ubuntu0.3                 amd64        system performance tools for Linux
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tcl-expect:amd64           5.45.4-2build1                    amd64        Automates interactive applications (Tcl package)
+ii  tcl8.6                     8.6.10+dfsg-1                     amd64        Tcl (the Tool Command Language) v8.6 - shell
+ii  tcpdump                    4.9.3-4ubuntu0.2                  amd64        command-line network traffic analyzer
+ii  telnet                     0.17-41.2build1                   amd64        basic telnet client
+ii  traceroute                 1:2.1.0-2                         amd64        Traces the route taken by packets over an IPv4/IPv6 network
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  ucf                        3.0038+nmu1                       all          Update Configuration File(s): preserve user changes to config files
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  vim                        2:8.1.2269-1ubuntu5.15            amd64        Vi IMproved - enhanced vi editor
+ii  vim-common                 2:8.1.2269-1ubuntu5.15            all          Vi IMproved - Common files
+ii  vim-runtime                2:8.1.2269-1ubuntu5.15            all          Vi IMproved - Runtime files
+ii  x11-common                 1:7.7+19ubuntu14                  all          X Window System (X.Org) infrastructure
+ii  xml-core                   0.18+nmu1                         all          XML infrastructure and XML catalog file support
+ii  xxd                        2:8.1.2269-1ubuntu5.15            amd64        tool to make (or reverse) a hex dump
+ii  xz-utils                   5.2.4-1ubuntu1.1                  amd64        XZ-format compression utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime

--- a/20.04/ubuntu-debug-20.04.20230725
+++ b/20.04/ubuntu-debug-20.04.20230725
@@ -1,0 +1,259 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-===============================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  awscli                     1.18.69-1ubuntu0.20.04.1          all          Universal Command Line Environment for AWS
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  bind9-dnsutils             1:9.16.1-0ubuntu2.15              amd64        Clients provided with BIND 9
+ii  bind9-host                 1:9.16.1-0ubuntu2.15              amd64        DNS Lookup Utility
+ii  bind9-libs:amd64           1:9.16.1-0ubuntu2.15              amd64        Shared Libraries used by BIND 9
+ii  binutils                   2.34-6ubuntu1.6                   amd64        GNU assembler, linker and binary utilities
+ii  binutils-common:amd64      2.34-6ubuntu1.6                   amd64        Common files for the GNU assembler, linker and binary utilities
+ii  binutils-x86-64-linux-gnu  2.34-6ubuntu1.6                   amd64        GNU binary utilities, for x86-64-linux-gnu target
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  docutils-common            0.16+dfsg-2                       all          text processing system for reStructuredText - common data
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  expect                     5.45.4-2build1                    amd64        Automates interactive applications
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  file                       1:5.38-4                          amd64        Recognize the type of data in a file using "magic" numbers
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gdb                        9.2-0ubuntu1~20.04.1              amd64        GNU Debugger
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  groff                      1.22.4-4build1                    amd64        GNU troff text-formatting system
+ii  groff-base                 1.22.4-4build1                    amd64        GNU troff text-formatting system (base system components)
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  iproute2                   5.5.0-1ubuntu1                    amd64        networking and traffic control tools
+ii  iputils-ping               3:20190709-3                      amd64        Tools to test the reachability of network hosts
+ii  jq                         1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor
+ii  less                       551-1ubuntu0.1                    amd64        pager program similar to more
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libasound2:amd64           1.2.2-2.1ubuntu2.5                amd64        shared library for ALSA applications
+ii  libasound2-data            1.2.2-2.1ubuntu2.5                all          Configuration files and profiles for ALSA drivers
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libbabeltrace1:amd64       1.5.8-1build1                     amd64        Babeltrace conversion libraries
+ii  libbinutils:amd64          2.34-6ubuntu1.6                   amd64        GNU binary utilities (private shared library)
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbsd0:amd64              0.10.0-1                          amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libcanberra0:amd64         0.30-7ubuntu1                     amd64        simple abstract interface for playing event sounds
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcap2:amd64              1:2.32-1ubuntu0.1                 amd64        POSIX 1003.1e capabilities (library)
+ii  libcap2-bin                1:2.32-1ubuntu0.1                 amd64        POSIX 1003.1e capabilities (utilities)
+ii  libcbor0.6:amd64           0.6.0-0ubuntu1                    amd64        library for parsing and generating CBOR (RFC 7049)
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libctf-nobfd0:amd64        2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, no BFD dependency)
+ii  libctf0:amd64              2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, BFD dependency)
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libdw1:amd64               0.176-1.1build1                   amd64        library that provides access to the DWARF debug information
+ii  libedit2:amd64             3.1-20191231-1                    amd64        BSD editline and history libraries
+ii  libelf1:amd64              0.176-1.1build1                   amd64        library to read and write ELF files
+ii  libexpat1:amd64            2.2.9-1ubuntu0.6                  amd64        XML parsing C library - runtime library
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libfido2-1:amd64           1.3.1-1ubuntu2                    amd64        library for generating and verifying FIDO 2.0 objects
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libglib2.0-0:amd64         2.64.6-1~ubuntu20.04.6            amd64        GLib library of C routines
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgpm2:amd64              1.20.7-5                          amd64        General Purpose Mouse - shared library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libice6:amd64              2:1.0.10-0ubuntu1                 amd64        X11 Inter-Client Exchange library
+ii  libicu66:amd64             66.1-2ubuntu2.1                   amd64        International Components for Unicode
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libjq1:amd64               1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor - shared library
+ii  libjson-c4:amd64           0.13.1+dfsg-7ubuntu0.3            amd64        JSON manipulation library - shared library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblmdb0:amd64             0.9.24-1                          amd64        Lightning Memory-Mapped Database shared library
+ii  libltdl7:amd64             2.4.6-14                          amd64        System independent dlopen wrapper for GNU libtool
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmagic-mgc               1:5.38-4                          amd64        File type determination library using "magic" numbers (compiled magic file)
+ii  libmagic1:amd64            1:5.38-4                          amd64        Recognize the type of data in a file using "magic" numbers - library
+ii  libmaxminddb0:amd64        1.4.2-0ubuntu1.20.04.1            amd64        IP geolocation database library
+ii  libmnl0:amd64              1.0.4-2                           amd64        minimalistic Netlink communication library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libmpdec2:amd64            2.4.2-3                           amd64        library for decimal floating point arithmetic (runtime library)
+ii  libmpfr6:amd64             4.0.2-1                           amd64        multiple precision floating-point computation
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libogg0:amd64              1.3.4-0ubuntu1                    amd64        Ogg bitstream library
+ii  libonig5:amd64             6.9.4-1                           amd64        regular expressions library
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcap0.8:amd64           1.9.1-3                           amd64        system interface for user-level packet capture
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libpython3-stdlib:amd64    3.8.2-0ubuntu2                    amd64        interactive high-level object-oriented language (default python3 version)
+ii  libpython3.8:amd64         3.8.10-0ubuntu1~20.04.8           amd64        Shared Python runtime library (version 3.8)
+ii  libpython3.8-minimal:amd64 3.8.10-0ubuntu1~20.04.8           amd64        Minimal subset of the Python language (version 3.8)
+ii  libpython3.8-stdlib:amd64  3.8.10-0ubuntu1~20.04.8           amd64        Interactive high-level object-oriented language (standard library, version 3.8)
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsensors-config          1:3.6.0-2ubuntu1.1                all          lm-sensors configuration files
+ii  libsensors5:amd64          1:3.6.0-2ubuntu1.1                amd64        library to read temperature/voltage/fan sensors
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsm6:amd64               2:1.2.3-1                         amd64        X11 Session Management library
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtcl8.6:amd64            8.6.10+dfsg-1                     amd64        Tcl (the Tool Command Language) v8.6 - run-time library files
+ii  libtdb1:amd64              1.4.5-0ubuntu0.20.04.1            amd64        Trivial Database - shared library
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libuchardet0:amd64         0.0.6-3build1                     amd64        universal charset detection library - shared library
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libunwind8:amd64           1.2.1-9ubuntu0.1                  amd64        library to determine the call-chain of a program - runtime
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libuv1:amd64               1.34.2-1ubuntu1.3                 amd64        asynchronous event notification library - runtime library
+ii  libvorbis0a:amd64          1.3.6-2ubuntu1                    amd64        decoder library for Vorbis General Audio Compression Codec
+ii  libvorbisfile3:amd64       1.3.6-2ubuntu1                    amd64        high-level API for Vorbis General Audio Compression Codec
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libx11-6:amd64             2:1.6.9-2ubuntu1.5                amd64        X11 client-side library
+ii  libx11-data                2:1.6.9-2ubuntu1.5                all          X11 client-side library
+ii  libxau6:amd64              1:1.0.9-0ubuntu1                  amd64        X11 authorisation library
+ii  libxaw7:amd64              2:1.0.13-1                        amd64        X11 Athena Widget library
+ii  libxcb1:amd64              1.14-2                            amd64        X C Binding
+ii  libxdmcp6:amd64            1:1.1.3-0ubuntu1                  amd64        X11 Display Manager Control Protocol library
+ii  libxext6:amd64             2:1.3.4-0ubuntu1                  amd64        X11 miscellaneous extension library
+ii  libxml2:amd64              2.9.10+dfsg-5ubuntu0.20.04.6      amd64        GNOME XML library
+ii  libxmu6:amd64              2:1.1.3-0ubuntu1                  amd64        X11 miscellaneous utility library
+ii  libxpm4:amd64              1:3.5.12-1ubuntu0.20.04.1         amd64        X11 pixmap library
+ii  libxt6:amd64               1:1.1.5-1                         amd64        X11 toolkit intrinsics library
+ii  libxtables12:amd64         1.8.4-3ubuntu2.1                  amd64        netfilter xtables library
+ii  libyaml-0-2:amd64          0.2.2-1                           amd64        Fast YAML 1.1 parser and emitter library
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  lv                         4.51-7                            amd64        Powerful Multilingual File Viewer
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mime-support               3.64ubuntu1                       all          MIME files 'mime.types' & 'mailcap', and support programs
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  mysql-client               8.0.33-0ubuntu0.20.04.2           all          MySQL database client (metapackage depending on the latest version)
+ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.2           amd64        MySQL database client binaries
+ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.2           amd64        MySQL database core client binaries
+ii  mysql-common               5.8+1.0.5ubuntu2                  all          MySQL database common files, e.g. /etc/mysql/my.cnf
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  net-tools                  1.60+git20180626.aebd88e-1ubuntu1 amd64        NET-3 networking toolkit
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssh-client             1:8.2p1-4ubuntu0.8                amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  python3                    3.8.2-0ubuntu2                    amd64        interactive high-level object-oriented language (default python3 version)
+ii  python3-botocore           1.16.19+repack-1ubuntu0.20.04.1   all          Low-level, data-driven core of boto 3 (Python 3)
+ii  python3-certifi            2019.11.28-1                      all          root certificates for validating SSL certs and verifying TLS hosts (python3)
+ii  python3-chardet            3.0.4-4build1                     all          universal character encoding detector for Python3
+ii  python3-colorama           0.4.3-1build1                     all          Cross-platform colored terminal text in Python - Python 3.x
+ii  python3-dateutil           2.7.3-3ubuntu1                    all          powerful extensions to the standard Python 3 datetime module
+ii  python3-docutils           0.16+dfsg-2                       all          text processing system for reStructuredText (implemented in Python 3)
+ii  python3-idna               2.8-1                             all          Python IDNA2008 (RFC 5891) handling (Python 3)
+ii  python3-jmespath           0.9.4-2ubuntu1                    all          JSON Matching Expressions (Python 3)
+ii  python3-magic              2:0.4.15-3                        all          python3 interface to the libmagic file type identification library
+ii  python3-minimal            3.8.2-0ubuntu2                    amd64        minimal subset of the Python language (default python3 version)
+ii  python3-pkg-resources      45.2.0-1ubuntu0.1                 all          Package Discovery and Resource Access using pkg_resources
+ii  python3-pyasn1             0.4.2-3build1                     all          ASN.1 library for Python (Python 3 module)
+ii  python3-requests           2.22.0-2ubuntu1.1                 all          elegant and simple HTTP library for Python3, built for human beings
+ii  python3-roman              2.0.0-3build1                     all          module for generating/analyzing Roman numerals for Python 3
+ii  python3-rsa                4.0-3                             all          Pure-Python RSA implementation (Python 3)
+ii  python3-s3transfer         0.3.3-1                           all          Amazon S3 Transfer Manager for Python3
+ii  python3-six                1.14.0-2                          all          Python 2 and 3 compatibility library (Python 3 interface)
+ii  python3-urllib3            1.25.8-2ubuntu0.2                 all          HTTP library with thread-safe connection pooling for Python3
+ii  python3-yaml               5.3.1-1ubuntu0.1                  amd64        YAML parser and emitter for Python3
+ii  python3.8                  3.8.10-0ubuntu1~20.04.8           amd64        Interactive high-level object-oriented language (version 3.8)
+ii  python3.8-minimal          3.8.10-0ubuntu1~20.04.8           amd64        Minimal subset of the Python language (version 3.8)
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  s3cmd                      2.0.2-1ubuntu1                    all          command-line Amazon S3 client
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sgml-base                  1.29.1                            all          SGML infrastructure and SGML catalog file support
+ii  sound-theme-freedesktop    0.8-2ubuntu1                      all          freedesktop.org sound theme
+ii  sqlite3                    3.31.1-4ubuntu0.5                 amd64        Command line interface for SQLite 3
+ii  strace                     5.5-3ubuntu1                      amd64        System call tracer
+ii  sysstat                    12.2.0-2ubuntu0.3                 amd64        system performance tools for Linux
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tcl-expect:amd64           5.45.4-2build1                    amd64        Automates interactive applications (Tcl package)
+ii  tcl8.6                     8.6.10+dfsg-1                     amd64        Tcl (the Tool Command Language) v8.6 - shell
+ii  tcpdump                    4.9.3-4ubuntu0.2                  amd64        command-line network traffic analyzer
+ii  telnet                     0.17-41.2build1                   amd64        basic telnet client
+ii  traceroute                 1:2.1.0-2                         amd64        Traces the route taken by packets over an IPv4/IPv6 network
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  ucf                        3.0038+nmu1                       all          Update Configuration File(s): preserve user changes to config files
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  vim                        2:8.1.2269-1ubuntu5.15            amd64        Vi IMproved - enhanced vi editor
+ii  vim-common                 2:8.1.2269-1ubuntu5.15            all          Vi IMproved - Common files
+ii  vim-runtime                2:8.1.2269-1ubuntu5.15            all          Vi IMproved - Runtime files
+ii  x11-common                 1:7.7+19ubuntu14                  all          X Window System (X.Org) infrastructure
+ii  xml-core                   0.18+nmu1                         all          XML infrastructure and XML catalog file support
+ii  xxd                        2:8.1.2269-1ubuntu5.15            amd64        tool to make (or reverse) a hex dump
+ii  xz-utils                   5.2.4-1ubuntu1.1                  amd64        XZ-format compression utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime

--- a/20.04/ubuntu-dev-20.04-new
+++ b/20.04/ubuntu-dev-20.04-new
@@ -1,0 +1,191 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-===============================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  binutils                   2.34-6ubuntu1.6                   amd64        GNU assembler, linker and binary utilities
+ii  binutils-common:amd64      2.34-6ubuntu1.6                   amd64        Common files for the GNU assembler, linker and binary utilities
+ii  binutils-x86-64-linux-gnu  2.34-6ubuntu1.6                   amd64        GNU binary utilities, for x86-64-linux-gnu target
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  build-essential            12.8ubuntu1.1                     amd64        Informational list of build-essential packages
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  cpp                        4:9.3.0-1ubuntu2                  amd64        GNU C preprocessor (cpp)
+ii  cpp-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C preprocessor
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  dpkg-dev                   1.19.7ubuntu3.2                   all          Debian package development tools
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  g++                        4:9.3.0-1ubuntu2                  amd64        GNU C++ compiler
+ii  g++-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C++ compiler
+ii  gcc                        4:9.3.0-1ubuntu2                  amd64        GNU C compiler
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gcc-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C compiler
+ii  gcc-9-base:amd64           9.4.0-1ubuntu1~20.04.1            amd64        GCC, the GNU Compiler Collection (base package)
+ii  git                        1:2.25.1-1ubuntu3.11              amd64        fast, scalable, distributed revision control system
+ii  git-man                    1:2.25.1-1ubuntu3.11              all          fast, scalable, distributed revision control system (manual pages)
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  jq                         1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasan5:amd64             9.4.0-1ubuntu1~20.04.1            amd64        AddressSanitizer -- a fast memory error detector
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libatomic1:amd64           10.3.0-1ubuntu1~20.04             amd64        support library providing __atomic built-in functions
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libbinutils:amd64          2.34-6ubuntu1.6                   amd64        GNU binary utilities (private shared library)
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbsd0:amd64              0.10.0-1                          amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc-dev-bin               2.31-0ubuntu9.9                   amd64        GNU C Library: Development binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libc6-dev:amd64            2.31-0ubuntu9.9                   amd64        GNU C Library: Development Libraries and Header Files
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcbor0.6:amd64           0.6.0-0ubuntu1                    amd64        library for parsing and generating CBOR (RFC 7049)
+ii  libcc1-0:amd64             10.3.0-1ubuntu1~20.04             amd64        GCC cc1 plugin for GDB
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt-dev:amd64         1:4.4.10-10ubuntu4                amd64        libcrypt development files
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libctf-nobfd0:amd64        2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, no BFD dependency)
+ii  libctf0:amd64              2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, BFD dependency)
+ii  libcurl3-gnutls:amd64      7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (GnuTLS flavour)
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libdpkg-perl               1.19.7ubuntu3.2                   all          Dpkg perl modules
+ii  libedit2:amd64             3.1-20191231-1                    amd64        BSD editline and history libraries
+ii  liberror-perl              0.17029-1                         all          Perl module for error/exception handling in an OO-ish way
+ii  libexpat1:amd64            2.2.9-1ubuntu0.6                  amd64        XML parsing C library - runtime library
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libfido2-1:amd64           1.3.1-1ubuntu2                    amd64        library for generating and verifying FIDO 2.0 objects
+ii  libgcc-9-dev:amd64         9.4.0-1ubuntu1~20.04.1            amd64        GCC support library (development files)
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libgdbm-compat4:amd64      1.18.1-5                          amd64        GNU dbm database routines (legacy support runtime version) 
+ii  libgdbm6:amd64             1.18.1-5                          amd64        GNU dbm database routines (runtime version) 
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgomp1:amd64             10.3.0-1ubuntu1~20.04             amd64        GCC OpenMP (GOMP) support library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libisl22:amd64             0.22.1-1                          amd64        manipulating sets and relations of integer points bounded by linear constraints
+ii  libitm1:amd64              10.3.0-1ubuntu1~20.04             amd64        GNU Transactional Memory Library
+ii  libjq1:amd64               1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor - shared library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblsan0:amd64             10.3.0-1ubuntu1~20.04             amd64        LeakSanitizer -- a memory leak detector (runtime)
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libmpc3:amd64              1.1.0-1                           amd64        multiple precision complex floating-point library
+ii  libmpfr6:amd64             4.0.2-1                           amd64        multiple precision floating-point computation
+ii  libncurses-dev:amd64       6.2-0ubuntu2.1                    amd64        developer's libraries for ncurses
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libonig5:amd64             6.9.4-1                           amd64        regular expressions library
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libperl5.30:amd64          5.30.0-9ubuntu0.4                 amd64        shared Perl library
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libquadmath0:amd64         10.3.0-1ubuntu1~20.04             amd64        GCC Quad-Precision Math Library
+ii  libreadline-dev:amd64      8.0-4                             amd64        GNU readline and history libraries, development files
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl-dev:amd64           1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - development files
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++-9-dev:amd64      9.4.0-1ubuntu1~20.04.1            amd64        GNU Standard C++ Library v3 (development files)
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libtsan0:amd64             10.3.0-1ubuntu1~20.04             amd64        ThreadSanitizer -- a Valgrind-based detector of data races (runtime)
+ii  libubsan1:amd64            10.3.0-1ubuntu1~20.04             amd64        UBSan -- undefined behaviour sanitizer (runtime)
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  linux-libc-dev:amd64       5.4.0-155.172                     amd64        Linux Kernel Headers for development
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  make                       4.2.1-1.2                         amd64        utility for directing compilation
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssh-client             1:8.2p1-4ubuntu0.8                amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  patch                      2.7.6-6                           amd64        Apply a diff file to an original
+ii  perl                       5.30.0-9ubuntu0.4                 amd64        Larry Wall's Practical Extraction and Report Language
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  perl-modules-5.30          5.30.0-9ubuntu0.4                 all          Core Perl modules
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  xz-utils                   5.2.4-1ubuntu1.1                  amd64        XZ-format compression utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime

--- a/20.04/ubuntu-dev-20.04.20230725
+++ b/20.04/ubuntu-dev-20.04.20230725
@@ -1,0 +1,191 @@
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                       Version                           Architecture Description
++++-==========================-=================================-============-===============================================================================
+ii  adduser                    3.118ubuntu2                      all          add and remove users and groups
+ii  apt                        2.0.9                             amd64        commandline package manager
+ii  apt-transport-https        2.0.9                             all          transitional package for https support
+ii  apt-utils                  2.0.9                             amd64        package management related utility programs
+ii  base-files                 11ubuntu5.7                       amd64        Debian base system miscellaneous files
+ii  base-passwd                3.5.47                            amd64        Debian base system master password and group files
+ii  bash                       5.0-6ubuntu1.2                    amd64        GNU Bourne Again SHell
+ii  binutils                   2.34-6ubuntu1.6                   amd64        GNU assembler, linker and binary utilities
+ii  binutils-common:amd64      2.34-6ubuntu1.6                   amd64        Common files for the GNU assembler, linker and binary utilities
+ii  binutils-x86-64-linux-gnu  2.34-6ubuntu1.6                   amd64        GNU binary utilities, for x86-64-linux-gnu target
+ii  bsdutils                   1:2.34-0.1ubuntu9.4               amd64        basic utilities from 4.4BSD-Lite
+ii  build-essential            12.8ubuntu1.1                     amd64        Informational list of build-essential packages
+ii  bzip2                      1.0.8-2                           amd64        high-quality block-sorting file compressor - utilities
+ii  ca-certificates            20230311ubuntu0.20.04.1           all          Common CA certificates
+ii  coreutils                  8.30-3ubuntu2                     amd64        GNU core utilities
+ii  cpp                        4:9.3.0-1ubuntu2                  amd64        GNU C preprocessor (cpp)
+ii  cpp-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C preprocessor
+ii  curl                       7.68.0-1ubuntu2.19                amd64        command line tool for transferring data with URL syntax
+ii  dash                       0.5.10.2-6                        amd64        POSIX-compliant shell
+ii  debconf                    1.5.73                            all          Debian configuration management system
+ii  debianutils                4.9.1                             amd64        Miscellaneous utilities specific to Debian
+ii  diffutils                  1:3.7-3                           amd64        File comparison utilities
+ii  dpkg                       1.19.7ubuntu3.2                   amd64        Debian package management system
+ii  dpkg-dev                   1.19.7ubuntu3.2                   all          Debian package development tools
+ii  e2fsprogs                  1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system utilities
+ii  fdisk                      2.34-0.1ubuntu9.4                 amd64        collection of partitioning utilities
+ii  findutils                  4.7.0-1ubuntu1                    amd64        utilities for finding files--find, xargs
+ii  g++                        4:9.3.0-1ubuntu2                  amd64        GNU C++ compiler
+ii  g++-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C++ compiler
+ii  gcc                        4:9.3.0-1ubuntu2                  amd64        GNU C compiler
+ii  gcc-10-base:amd64          10.3.0-1ubuntu1~20.04             amd64        GCC, the GNU Compiler Collection (base package)
+ii  gcc-9                      9.4.0-1ubuntu1~20.04.1            amd64        GNU C compiler
+ii  gcc-9-base:amd64           9.4.0-1ubuntu1~20.04.1            amd64        GCC, the GNU Compiler Collection (base package)
+ii  git                        1:2.25.1-1ubuntu3.11              amd64        fast, scalable, distributed revision control system
+ii  git-man                    1:2.25.1-1ubuntu3.11              all          fast, scalable, distributed revision control system (manual pages)
+ii  gpgv                       2.2.19-3ubuntu2.2                 amd64        GNU privacy guard - signature verification tool
+ii  grep                       3.4-1                             amd64        GNU grep, egrep and fgrep
+ii  gzip                       1.10-0ubuntu4.1                   amd64        GNU compression utilities
+ii  hostname                   3.23                              amd64        utility to set/show the host name or domain name
+ii  init-system-helpers        1.57                              all          helper tools for all init systems
+ii  jq                         1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor
+ii  libacl1:amd64              2.2.53-6                          amd64        access control list - shared library
+ii  libapt-pkg6.0:amd64        2.0.9                             amd64        package management runtime library
+ii  libasan5:amd64             9.4.0-1ubuntu1~20.04.1            amd64        AddressSanitizer -- a fast memory error detector
+ii  libasn1-8-heimdal:amd64    7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - ASN.1 library
+ii  libatomic1:amd64           10.3.0-1ubuntu1~20.04             amd64        support library providing __atomic built-in functions
+ii  libattr1:amd64             1:2.4.48-5                        amd64        extended attribute handling - shared library
+ii  libaudit-common            1:2.8.5-2ubuntu6                  all          Dynamic library for security auditing - common files
+ii  libaudit1:amd64            1:2.8.5-2ubuntu6                  amd64        Dynamic library for security auditing
+ii  libbinutils:amd64          2.34-6ubuntu1.6                   amd64        GNU binary utilities (private shared library)
+ii  libblkid1:amd64            2.34-0.1ubuntu9.4                 amd64        block device ID library
+ii  libbrotli1:amd64           1.0.7-6ubuntu0.1                  amd64        library implementing brotli encoder and decoder (shared libraries)
+ii  libbsd0:amd64              0.10.0-1                          amd64        utility functions from BSD systems - shared library
+ii  libbz2-1.0:amd64           1.0.8-2                           amd64        high-quality block-sorting file compressor library - runtime
+ii  libc-bin                   2.31-0ubuntu9.9                   amd64        GNU C Library: Binaries
+ii  libc-dev-bin               2.31-0ubuntu9.9                   amd64        GNU C Library: Development binaries
+ii  libc6:amd64                2.31-0ubuntu9.9                   amd64        GNU C Library: Shared libraries
+ii  libc6-dev:amd64            2.31-0ubuntu9.9                   amd64        GNU C Library: Development Libraries and Header Files
+ii  libcap-ng0:amd64           0.7.9-2.1build1                   amd64        An alternate POSIX capabilities library
+ii  libcbor0.6:amd64           0.6.0-0ubuntu1                    amd64        library for parsing and generating CBOR (RFC 7049)
+ii  libcc1-0:amd64             10.3.0-1ubuntu1~20.04             amd64        GCC cc1 plugin for GDB
+ii  libcom-err2:amd64          1.45.5-2ubuntu1.1                 amd64        common error description library
+ii  libcrypt-dev:amd64         1:4.4.10-10ubuntu4                amd64        libcrypt development files
+ii  libcrypt1:amd64            1:4.4.10-10ubuntu4                amd64        libcrypt shared library
+ii  libctf-nobfd0:amd64        2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, no BFD dependency)
+ii  libctf0:amd64              2.34-6ubuntu1.6                   amd64        Compact C Type Format library (runtime, BFD dependency)
+ii  libcurl3-gnutls:amd64      7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (GnuTLS flavour)
+ii  libcurl4:amd64             7.68.0-1ubuntu2.19                amd64        easy-to-use client-side URL transfer library (OpenSSL flavour)
+ii  libdb5.3:amd64             5.3.28+dfsg1-0.6ubuntu2           amd64        Berkeley v5.3 Database Libraries [runtime]
+ii  libdebconfclient0:amd64    0.251ubuntu1                      amd64        Debian Configuration Management System (C-implementation library)
+ii  libdpkg-perl               1.19.7ubuntu3.2                   all          Dpkg perl modules
+ii  libedit2:amd64             3.1-20191231-1                    amd64        BSD editline and history libraries
+ii  liberror-perl              0.17029-1                         all          Perl module for error/exception handling in an OO-ish way
+ii  libexpat1:amd64            2.2.9-1ubuntu0.6                  amd64        XML parsing C library - runtime library
+ii  libext2fs2:amd64           1.45.5-2ubuntu1.1                 amd64        ext2/ext3/ext4 file system libraries
+ii  libfdisk1:amd64            2.34-0.1ubuntu9.4                 amd64        fdisk partitioning library
+ii  libffi7:amd64              3.3-4                             amd64        Foreign Function Interface library runtime
+ii  libfido2-1:amd64           1.3.1-1ubuntu2                    amd64        library for generating and verifying FIDO 2.0 objects
+ii  libgcc-9-dev:amd64         9.4.0-1ubuntu1~20.04.1            amd64        GCC support library (development files)
+ii  libgcc-s1:amd64            10.3.0-1ubuntu1~20.04             amd64        GCC support library
+ii  libgcrypt20:amd64          1.8.5-5ubuntu1.1                  amd64        LGPL Crypto library - runtime library
+ii  libgdbm-compat4:amd64      1.18.1-5                          amd64        GNU dbm database routines (legacy support runtime version) 
+ii  libgdbm6:amd64             1.18.1-5                          amd64        GNU dbm database routines (runtime version) 
+ii  libgmp10:amd64             2:6.2.0+dfsg-4ubuntu0.1           amd64        Multiprecision arithmetic library
+ii  libgnutls30:amd64          3.6.13-2ubuntu1.8                 amd64        GNU TLS library - main runtime library
+ii  libgomp1:amd64             10.3.0-1ubuntu1~20.04             amd64        GCC OpenMP (GOMP) support library
+ii  libgpg-error0:amd64        1.37-1                            amd64        GnuPG development runtime library
+ii  libgssapi-krb5-2:amd64     1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
+ii  libgssapi3-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - GSSAPI support library
+ii  libhcrypto4-heimdal:amd64  7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - crypto library
+ii  libheimbase1-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - Base library
+ii  libheimntlm0-heimdal:amd64 7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - NTLM support library
+ii  libhogweed5:amd64          3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (public-key cryptos)
+ii  libhx509-5-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - X509 support library
+ii  libidn2-0:amd64            2.2.0-2                           amd64        Internationalized domain names (IDNA2008/TR46) library
+ii  libisl22:amd64             0.22.1-1                          amd64        manipulating sets and relations of integer points bounded by linear constraints
+ii  libitm1:amd64              10.3.0-1ubuntu1~20.04             amd64        GNU Transactional Memory Library
+ii  libjq1:amd64               1.6-1ubuntu0.20.04.1              amd64        lightweight and flexible command-line JSON processor - shared library
+ii  libk5crypto3:amd64         1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Crypto Library
+ii  libkeyutils1:amd64         1.6-6ubuntu1.1                    amd64        Linux Key Management Utilities (library)
+ii  libkrb5-26-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - libraries
+ii  libkrb5-3:amd64            1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries
+ii  libkrb5support0:amd64      1.17-6ubuntu4.3                   amd64        MIT Kerberos runtime libraries - Support library
+ii  libldap-2.4-2:amd64        2.4.49+dfsg-2ubuntu1.9            amd64        OpenLDAP libraries
+ii  libldap-common             2.4.49+dfsg-2ubuntu1.9            all          OpenLDAP common files for libraries
+ii  liblsan0:amd64             10.3.0-1ubuntu1~20.04             amd64        LeakSanitizer -- a memory leak detector (runtime)
+ii  liblz4-1:amd64             1.9.2-2ubuntu0.20.04.1            amd64        Fast LZ compression algorithm library - runtime
+ii  liblzma5:amd64             5.2.4-1ubuntu1.1                  amd64        XZ-format compression library
+ii  libmount1:amd64            2.34-0.1ubuntu9.4                 amd64        device mounting library
+ii  libmpc3:amd64              1.1.0-1                           amd64        multiple precision complex floating-point library
+ii  libmpfr6:amd64             4.0.2-1                           amd64        multiple precision floating-point computation
+ii  libncurses-dev:amd64       6.2-0ubuntu2.1                    amd64        developer's libraries for ncurses
+ii  libncurses6:amd64          6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling
+ii  libncursesw6:amd64         6.2-0ubuntu2.1                    amd64        shared libraries for terminal handling (wide character support)
+ii  libnettle7:amd64           3.5.1+really3.5.1-2ubuntu0.2      amd64        low level cryptographic library (symmetric and one-way cryptos)
+ii  libnghttp2-14:amd64        1.40.0-1ubuntu0.1                 amd64        library implementing HTTP/2 protocol (shared library)
+ii  libonig5:amd64             6.9.4-1                           amd64        regular expressions library
+ii  libp11-kit0:amd64          0.23.20-1ubuntu0.1                amd64        library for loading and coordinating access to PKCS#11 modules - runtime
+ii  libpam-modules:amd64       1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM
+ii  libpam-modules-bin         1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules for PAM - helper binaries
+ii  libpam-runtime             1.3.1-5ubuntu4.6                  all          Runtime support for the PAM library
+ii  libpam0g:amd64             1.3.1-5ubuntu4.6                  amd64        Pluggable Authentication Modules library
+ii  libpcre2-8-0:amd64         10.34-7ubuntu0.1                  amd64        New Perl Compatible Regular Expression Library- 8 bit runtime files
+ii  libpcre3:amd64             2:8.39-12ubuntu0.1                amd64        Old Perl 5 Compatible Regular Expression Library - runtime files
+ii  libperl5.30:amd64          5.30.0-9ubuntu0.4                 amd64        shared Perl library
+ii  libprocps8:amd64           2:3.3.16-1ubuntu2.3               amd64        library for accessing process information from /proc
+ii  libpsl5:amd64              0.21.0-1ubuntu1                   amd64        Library for Public Suffix List (shared libraries)
+ii  libquadmath0:amd64         10.3.0-1ubuntu1~20.04             amd64        GCC Quad-Precision Math Library
+ii  libreadline-dev:amd64      8.0-4                             amd64        GNU readline and history libraries, development files
+ii  libreadline8:amd64         8.0-4                             amd64        GNU readline and history libraries, run-time libraries
+ii  libroken18-heimdal:amd64   7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - roken support library
+ii  librtmp1:amd64             2.4+20151223.gitfa8646d.1-2build1 amd64        toolkit for RTMP streams (shared library)
+ii  libsasl2-2:amd64           2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - authentication abstraction library
+ii  libsasl2-modules-db:amd64  2.1.27+dfsg-2ubuntu0.1            amd64        Cyrus SASL - pluggable authentication modules (DB)
+ii  libseccomp2:amd64          2.5.1-1ubuntu1~20.04.2            amd64        high level interface to Linux seccomp filter
+ii  libselinux1:amd64          3.0-1build2                       amd64        SELinux runtime shared libraries
+ii  libsemanage-common         3.0-1build2                       all          Common files for SELinux policy management libraries
+ii  libsemanage1:amd64         3.0-1build2                       amd64        SELinux policy management library
+ii  libsepol1:amd64            3.0-1ubuntu0.1                    amd64        SELinux library for manipulating binary security policies
+ii  libsmartcols1:amd64        2.34-0.1ubuntu9.4                 amd64        smart column output alignment library
+ii  libsqlite3-0:amd64         3.31.1-4ubuntu0.5                 amd64        SQLite 3 shared library
+ii  libss2:amd64               1.45.5-2ubuntu1.1                 amd64        command-line interface parsing library
+ii  libssh-4:amd64             0.9.3-2ubuntu2.3                  amd64        tiny C SSH library (OpenSSL flavor)
+ii  libssl-dev:amd64           1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - development files
+ii  libssl1.1:amd64            1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - shared libraries
+ii  libstdc++-9-dev:amd64      9.4.0-1ubuntu1~20.04.1            amd64        GNU Standard C++ Library v3 (development files)
+ii  libstdc++6:amd64           10.3.0-1ubuntu1~20.04             amd64        GNU Standard C++ Library v3
+ii  libsystemd0:amd64          245.4-4ubuntu3.22                 amd64        systemd utility library
+ii  libtasn1-6:amd64           4.16.0-2                          amd64        Manage ASN.1 structures (runtime)
+ii  libtinfo6:amd64            6.2-0ubuntu2.1                    amd64        shared low-level terminfo library for terminal handling
+ii  libtsan0:amd64             10.3.0-1ubuntu1~20.04             amd64        ThreadSanitizer -- a Valgrind-based detector of data races (runtime)
+ii  libubsan1:amd64            10.3.0-1ubuntu1~20.04             amd64        UBSan -- undefined behaviour sanitizer (runtime)
+ii  libudev1:amd64             245.4-4ubuntu3.22                 amd64        libudev shared library
+ii  libunistring2:amd64        0.9.10-2                          amd64        Unicode string library for C
+ii  libuuid1:amd64             2.34-0.1ubuntu9.4                 amd64        Universally Unique ID library
+ii  libwind0-heimdal:amd64     7.7.0+dfsg-1ubuntu1.4             amd64        Heimdal Kerberos - stringprep implementation
+ii  libzstd1:amd64             1.4.4+dfsg-3ubuntu0.1             amd64        fast lossless compression algorithm
+ii  linux-libc-dev:amd64       5.4.0-155.172                     amd64        Linux Kernel Headers for development
+ii  locales                    2.31-0ubuntu9.9                   all          GNU C Library: National Language (locale) data [support]
+ii  login                      1:4.8.1-1ubuntu5.20.04.4          amd64        system login tools
+ii  logsave                    1.45.5-2ubuntu1.1                 amd64        save the output of a command in a log file
+ii  lsb-base                   11.1.0ubuntu2                     all          Linux Standard Base init script functionality
+ii  make                       4.2.1-1.2                         amd64        utility for directing compilation
+ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
+ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
+ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
+ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
+ii  netbase                    6.1                               all          Basic TCP/IP networking system
+ii  openssh-client             1:8.2p1-4ubuntu0.8                amd64        secure shell (SSH) client, for secure access to remote machines
+ii  openssl                    1.1.1f-1ubuntu2.19                amd64        Secure Sockets Layer toolkit - cryptographic utility
+ii  passwd                     1:4.8.1-1ubuntu5.20.04.4          amd64        change and administer password and group data
+ii  patch                      2.7.6-6                           amd64        Apply a diff file to an original
+ii  perl                       5.30.0-9ubuntu0.4                 amd64        Larry Wall's Practical Extraction and Report Language
+ii  perl-base                  5.30.0-9ubuntu0.4                 amd64        minimal Perl system
+ii  perl-modules-5.30          5.30.0-9ubuntu0.4                 all          Core Perl modules
+ii  procps                     2:3.3.16-1ubuntu2.3               amd64        /proc file system utilities
+ii  readline-common            8.0-4                             all          GNU readline and history libraries, common files
+ii  sed                        4.7-1                             amd64        GNU stream editor for filtering/transforming text
+ii  sensible-utils             0.0.12+nmu1                       all          Utilities for sensible alternative selection
+ii  sysvinit-utils             2.96-2.1ubuntu1                   amd64        System-V-like utilities
+ii  tar                        1.30+dfsg-7ubuntu0.20.04.3        amd64        GNU version of the tar archiving utility
+ii  tzdata                     2023c-0ubuntu0.20.04.2            all          time zone and daylight-saving time data
+ii  ubuntu-keyring             2020.02.11.4                      all          GnuPG keys of the Ubuntu archive
+ii  util-linux                 2.34-0.1ubuntu9.4                 amd64        miscellaneous system utilities
+ii  xz-utils                   5.2.4-1ubuntu1.1                  amd64        XZ-format compression utilities
+ii  zlib1g:amd64               1:1.2.11.dfsg-2ubuntu1.5          amd64        compression library - runtime


### PR DESCRIPTION
Update images for 20.04
- Minimal image updated: focal-20230624
- ubuntu-debug:20.04: package updated
```diff
--- ubuntu-debug-20.04.20230725	2023-07-25 22:04:42.553645107 +0000
+++ ubuntu-debug-20.04-new	2023-07-25 22:04:42.989650413 +0000
@@ -194,9 +194,9 @@
 ii  mawk                       1.3.4.20200120-2                  amd64        Pattern scanning and text processing language
 ii  mime-support               3.64ubuntu1                       all          MIME files 'mime.types' & 'mailcap', and support programs
 ii  mount                      2.34-0.1ubuntu9.4                 amd64        tools for mounting and manipulating filesystems
-ii  mysql-client               8.0.33-0ubuntu0.20.04.2           all          MySQL database client (metapackage depending on the latest version)
-ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.2           amd64        MySQL database client binaries
-ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.2           amd64        MySQL database core client binaries
+ii  mysql-client               8.0.33-0ubuntu0.20.04.4           all          MySQL database client (metapackage depending on the latest version)
+ii  mysql-client-8.0           8.0.33-0ubuntu0.20.04.4           amd64        MySQL database client binaries
+ii  mysql-client-core-8.0      8.0.33-0ubuntu0.20.04.4           amd64        MySQL database core client binaries
 ii  mysql-common               5.8+1.0.5ubuntu2                  all          MySQL database common files, e.g. /etc/mysql/my.cnf
 ii  ncurses-base               6.2-0ubuntu2.1                    all          basic terminal type definitions
 ii  ncurses-bin                6.2-0ubuntu2.1                    amd64        terminal-related programs and man pages
```

