### PR TITLE
Modify the build orders for the repositories

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Build and push ubuntu-minimal image if needed
         run: |
           TAG_MINIMAL=$(cat TAG_MINIMAL)
-          for repo in quay.io ghcr.io; do
+          for repo in ghcr.io quay.io; do
             c="$(container-tag-exists ${repo}/cybozu/ubuntu-minimal $TAG_MINIMAL 2>&1)"
             if [ "$c" = "" ]; then
               echo
@@ -60,7 +60,7 @@ jobs:
       - name: Extract targets
         run: |
           TAG=$(cat TAG)
-          for repo in quay.io ghcr.io; do
+          for repo in ghcr.io quay.io; do
             for image in ubuntu ubuntu-dev ubuntu-debug; do
                 c="$(container-tag-exists ${repo}/cybozu/$image $TAG 2>&1)"
                 if [ "$c" = "" ]; then


### PR DESCRIPTION
To fix build error caused by use base image as `ghcr.io` in Dockerfiles, modified the build orders for the repositories.