### PR TITLE
Changed to execute a scan job when the build job is finished.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,9 @@ jobs:
                 fi
             done
           done
+          if [ -f BUILDS ]; then
+            echo "builds=$(cat BUILDS | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images
@@ -107,13 +110,13 @@ jobs:
         env:
           YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
         run: |
-          if [ ! -f BUILDS ]; then
+          if [ -z "${{ needs.build.outputs.builds }}" ]; then
               echo "nothing to scan."
               exit 0
           fi
           TAG=$(cat TAG)
           BRANCH=$(cat BRANCH)
-          for d in $(cat BUILDS); do
+          for d in ${{ needs.build.outputs.builds }}; do
               echo
               echo "scanning $d:$TAG ..."
               YAMORY_IMAGE_IDENTIFIER="${d}:$BRANCH" YAMORY_IMAGE_NAME="${d}:$TAG" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 env:
   go-version: 1.23
 jobs:
-  build:
+  release:
     name: Build and release images
     strategy:
       fail-fast: false
@@ -98,7 +98,7 @@ jobs:
   scan:
     name: Scan images
     runs-on: ubuntu-24.04
-    needs: build
+    needs: release
     env:
       YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
       ubuntu-version: "20.04 22.04 24.04"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,9 +70,6 @@ jobs:
                 fi
             done
           done
-          if [ -f BUILDS ]; then
-            echo "builds=$(cat BUILDS | tr '\n' ' ')" >> $GITHUB_OUTPUT
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push images

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,12 +112,10 @@ jobs:
       - name: Scan images
         run: |
           for ubuntu_version in ${{ env.ubuntu-version }}; do
-            cd ${ubuntu_version}
-            TAG=$(cat TAG)
+            TAG=$(cat ${ubuntu_version}/TAG)
             for ubuntu_image in ${{ env.ubuntu-image }}; do
               echo
               echo "scanning ${ubuntu_image}:${TAG} ..."
               YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
             done
-            cd ../
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,11 +63,11 @@ jobs:
           TAG=$(cat TAG)
           for repo in ghcr.io quay.io; do
             for image in ubuntu ubuntu-dev ubuntu-debug; do
-                c="$(container-tag-exists ${repo}/cybozu/$image $TAG 2>&1)"
-                if [ "$c" = "" ]; then
-                    echo "build ${repo}/cybozu/$image:$TAG"
-                    echo ${repo}/cybozu/$image >> BUILDS
-                fi
+              c="$(container-tag-exists ${repo}/cybozu/$image $TAG 2>&1)"
+              if [ "$c" = "" ]; then
+                echo "build ${repo}/cybozu/$image:$TAG"
+                echo ${repo}/cybozu/$image >> BUILDS
+              fi
             done
           done
         env:
@@ -75,24 +75,24 @@ jobs:
       - name: Build and push images
         run: |
           if [ ! -f BUILDS ]; then
-              echo "nothing to build."
-              exit 0
+            echo "nothing to build."
+            exit 0
           fi
           TAG_MINIMAL=$(cat TAG_MINIMAL)
           TAG=$(cat TAG)
           BRANCH=$(cat BRANCH)
           for d in $(cat BUILDS); do
-              echo
-              echo "building $d ..."
-              dir=$(echo ${d} | awk -F'/' '{print $3}')
-              docker buildx build \
-                --platform linux/amd64,linux/arm64/v8 \
-                --push \
-                -t ${d}:$TAG \
-                -t ${d}:$BRANCH \
-                --build-arg TAG_MINIMAL=$TAG_MINIMAL \
-                --build-arg TAG=$TAG \
-                ${dir}
+            echo
+            echo "building $d ..."
+            dir=$(echo ${d} | awk -F'/' '{print $3}')
+            docker buildx build \
+              --platform linux/amd64,linux/arm64/v8 \
+              --push \
+              -t ${d}:$TAG \
+              -t ${d}:$BRANCH \
+              --build-arg TAG_MINIMAL=$TAG_MINIMAL \
+              --build-arg TAG=$TAG \
+              ${dir}
           done
 
   scan:
@@ -110,12 +110,12 @@ jobs:
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - name: Scan images
         run: |
-            for ubuntu_version in ${{ env.ubuntu-version }}; do
-              cd $ubuntu_version
-              TAG=$(cat TAG)
-              for ubuntu_image in ${{ env.ubuntu-image }}; do
-                  echo
-                  echo "scanning ${ubuntu_image}:${TAG} ..."
-                  YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
-              done
+          for ubuntu_version in ${{ env.ubuntu-version }}; do
+            cd $ubuntu_version
+            TAG=$(cat TAG)
+            for ubuntu_image in ${{ env.ubuntu-image }}; do
+              echo
+              echo "scanning ${ubuntu_image}:${TAG} ..."
+              YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
             done
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,9 @@ jobs:
     name: Scan images
     runs-on: ubuntu-24.04
     needs: build
+    defaults:
+      run:
+        working-directory: ${{ matrix.ubuntu-version }}
     steps:
       - name: Install Trivy
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,25 +102,23 @@ jobs:
     name: Scan images
     runs-on: ubuntu-24.04
     needs: build
-    defaults:
-      run:
-        working-directory: ${{ matrix.ubuntu-version }}
+    env:
+      YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
+      ubuntu-version: "20.04 22.04 24.04"
+      ubuntu-image: "ubuntu-debug ubuntu-dev"
+
     steps:
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - name: Scan images
-        env:
-          YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
         run: |
-          if [ -z "${{ needs.build.outputs.builds }}" ]; then
-              echo "nothing to scan."
-              exit 0
-          fi
-          TAG=$(cat TAG)
-          BRANCH=$(cat BRANCH)
-          for d in ${{ needs.build.outputs.builds }}; do
-              echo
-              echo "scanning $d:$TAG ..."
-              YAMORY_IMAGE_IDENTIFIER="${d}:$BRANCH" YAMORY_IMAGE_NAME="${d}:$TAG" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
-          done
+            for ubuntu_version in ${{ env.ubuntu-version }}; do
+              cd $ubuntu_version
+              TAG=$(cat TAG)
+              for ubuntu_image in ${{ env.ubuntu-image }}; do
+                  echo
+                  echo "scanning ${ubuntu_image}:${TAG} ..."
+                  YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
+              done
+            done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,8 @@ on:
 env:
   go-version: 1.23
 jobs:
-  release:
-    name: release images
+  build:
+    name: Build and release images
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +94,12 @@ jobs:
                 --build-arg TAG=$TAG \
                 ${dir}
           done
+
+  scan:
+    name: Scan images
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,6 +116,6 @@ jobs:
             for ubuntu_image in ${{ env.ubuntu-image }}; do
               echo
               echo "scanning ${ubuntu_image}:${TAG} ..."
-              YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
+              YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="ghcr.io/cybozu/${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
             done
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,19 +103,21 @@ jobs:
       YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
       ubuntu-version: "20.04 22.04 24.04"
       ubuntu-image: "ubuntu-debug ubuntu-dev"
-
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Install Trivy
         run: |
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - name: Scan images
         run: |
           for ubuntu_version in ${{ env.ubuntu-version }}; do
-            cd $ubuntu_version
+            cd ${ubuntu_version}
             TAG=$(cat TAG)
             for ubuntu_image in ${{ env.ubuntu-image }}; do
               echo
               echo "scanning ${ubuntu_image}:${TAG} ..."
               YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
             done
+            cd ../
           done


### PR DESCRIPTION
#### Overview
- Changed to execute a scan job when the build job is finished.

#### Why 
- Due to the increasing frequency of yamory scan failures

#### What
- I did not want to execute `curl -sSf -L https://mw-receiver.yamory.io/image/script/trivyin` in parallel.
- For this reason, I used a for loop and other methods to execute the scan sequentially.
- I also made changes to use the needs context so that the scan is executed after the build is complete.
- Due to the separation of jobs, it became difficult to pass data in the BUILDS file created during the build, so I decided to execute the scan by putting the image name in an environment variable.