### PR TITLE
fix: Update GitHub Actions token and set permissions

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -7,8 +7,11 @@ jobs:
   update:
     name: Update images
     env:
-      GH_TOKEN: ${{ secrets.CYBOZU_NECO_PAT }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       UBUNTU_VERSION: "20.04 22.04 24.04"
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Overview
- Stop using CYBOZU_NECO_PAT

### What 
- Changed GH_TOKEN from `CYBOZU_NECO_PAT` to `GITHUB_TOKEN`
- Added permissions settings