### PR TITLE
Fix workflow to correctly handle TAG_MINIMAL updates and version tagging

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -53,9 +53,9 @@ jobs:
         shell: bash -xe {0}
         run: |
           docker buildx use default
+          updated_versions=(${{ env.UPDATED_VERSIONS }})
 
-          for version in ${UPDATED_VERSIONS}; do
-            echo cat ./$version/TAG_MINIMAL: $(cat ./$version/TAG_MINIMAL)
+          for version in ${{ env.UBUNTU_VERSION }}; do
             TAG_MINIMAL=$(cat ./$version/TAG_MINIMAL)
             TAG=$(cat ./$version/TAG)
 
@@ -71,6 +71,7 @@ jobs:
                 echo '```diff' >> ./BODY
                 diff -u $img-$TAG $img-${version}-new >> ./BODY || true
                 echo -e '```\n' >> ./BODY
+                updated_versions+=($version)
               fi
             done
 
@@ -79,6 +80,8 @@ jobs:
               docker image rm ghcr.io/cybozu/$img:${version}-new
             done
           done
+
+          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >>$GITHUB_ENV
       - name: Create PR
         if: env.UPDATED_VERSIONS != ''
         shell: bash -xe {0}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -20,6 +20,7 @@ jobs:
         shell: bash -xe {0}
         run: |
           TOKEN=$(curl -sSf "https://auth.docker.io/token?scope=repository%3Alibrary%2Fubuntu%3Apull&service=registry.docker.io"| jq -r .token)
+          updated_versions=()
 
           for version in ${{ env.UBUNTU_VERSION }}; do
             if [ "${version}" = "20.04" ]; then
@@ -42,16 +43,19 @@ jobs:
 
             if [[ "$TAG_MINIMAL" != "$LATEST_TAG" ]]; then
               echo $LATEST_TAG > ./$version/TAG_MINIMAL
-              echo "NEED_UPDATE=1" >> $GITHUB_ENV
+              updated_versions+=($version)
               echo "- Update $version minimal image from $TAG_MINIMAL to $LATEST_TAG" >> ./BODY
             fi
           done
+
+          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >>$GITHUB_ENV
       - name: Check package updates
         shell: bash -xe {0}
         run: |
           docker buildx use default
 
-          for version in ${{ env.UBUNTU_VERSION }}; do
+          for version in ${UPDATED_VERSIONS}; do
+            echo cat ./$version/TAG_MINIMAL: $(cat ./$version/TAG_MINIMAL)
             TAG_MINIMAL=$(cat ./$version/TAG_MINIMAL)
             TAG=$(cat ./$version/TAG)
 
@@ -67,9 +71,6 @@ jobs:
                 echo '```diff' >> ./BODY
                 diff -u $img-$TAG $img-${version}-new >> ./BODY || true
                 echo -e '```\n' >> ./BODY
-                if [ "$NEED_UPDATE" != "1" ]; then
-                  echo "NEED_UPDATE=1" >> $GITHUB_ENV
-                fi
               fi
             done
 
@@ -79,12 +80,12 @@ jobs:
             done
           done
       - name: Create PR
-        if: env.NEED_UPDATE == '1'
+        if: env.UPDATED_VERSIONS != ''
         shell: bash -xe {0}
         run: |
           TODAY=$(TZ="Asia/Tokyo" date "+%Y%m%d")
 
-          for version in ${{ env.UBUNTU_VERSION }}; do
+          for version in ${UPDATED_VERSIONS}; do
             echo $version.$TODAY > ./$version/TAG
           done
 

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -48,7 +48,7 @@ jobs:
             fi
           done
 
-          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >>$GITHUB_ENV
+          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >> $GITHUB_ENV
       - name: Check package updates
         shell: bash -xe {0}
         run: |
@@ -81,7 +81,7 @@ jobs:
             done
           done
 
-          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >>$GITHUB_ENV
+          echo "UPDATED_VERSIONS=$(printf '%s\n' "${updated_versions[@]}" | paste -sd ' ')" >> $GITHUB_ENV
       - name: Create PR
         if: env.UPDATED_VERSIONS != ''
         shell: bash -xe {0}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -39,9 +39,9 @@ jobs:
             fi
 
             TAG_MINIMAL=$(cat ./$version/TAG_MINIMAL)
-            echo $LATEST_TAG > ./$version/TAG_MINIMAL
 
             if [[ "$TAG_MINIMAL" != "$LATEST_TAG" ]]; then
+              echo $LATEST_TAG > ./$version/TAG_MINIMAL
               echo "NEED_UPDATE=1" >> $GITHUB_ENV
               echo "- Update $version minimal image from $TAG_MINIMAL to $LATEST_TAG" >> ./BODY
             fi


### PR DESCRIPTION
### Overview
This commit updates the workflow to store updated versions for minimal image tagging.

### What
- Modified the `Check minimal image updates` step to save `LATEST_TAG` as an environment variable.
- Used the `updated_versions` array to collect versions that need updates and set them in the `UPDATED_VERSIONS` environment variable.
- Modified the `Create PR` step to retrieve `UPDATED_VERSIONS` from the environment variable and update the corresponding version `TAG` files.
- Updated the `Check package updates` step to process only the versions that need updates using the `UPDATED_VERSIONS` environment variable.

### Why
- To resolve the issue where the `LATEST_TAG` value is not carried over to the next step, causing the `TAG` files for each version to not be updated correctly.
- To ensure that the minimal image tags for each version are updated only when they differ from the latest tag.
- To avoid processing unnecessary versions and perform updates efficiently.

### Ref
- https://github.com/cybozu/ubuntu-base/pull/297