### PR TITLE
Update image scanning workflow to support multiple repositories

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,11 +111,13 @@ jobs:
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
       - name: Scan images
         run: |
-          for ubuntu_version in ${{ env.ubuntu-version }}; do
-            TAG=$(cat ${ubuntu_version}/TAG)
-            for ubuntu_image in ${{ env.ubuntu-image }}; do
-              echo
-              echo "scanning ${ubuntu_image}:${TAG} ..."
-              YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="ghcr.io/cybozu/${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
+          for repo in ghcr.io quay.io; do
+            for ubuntu_version in ${{ env.ubuntu-version }}; do
+              TAG=$(cat ${ubuntu_version}/TAG)
+              for ubuntu_image in ${{ env.ubuntu-image }}; do
+                echo
+                echo "scanning ${repo}/cybozu/${ubuntu_image}:${TAG} ..."
+                YAMORY_IMAGE_IDENTIFIER="${repo}/cybozu/${ubuntu_image}:${ubuntu_version}" YAMORY_IMAGE_NAME="${repo}/cybozu/${ubuntu_image}:${TAG}" bash -c "$(curl -sSf -L https://mw-receiver.yamory.io/image/script/trivy)"
+              done
             done
           done


### PR DESCRIPTION
### Overview
<!-- Write a summary of the content in one line -->
Fix the issue where quay.io images were not being scanned in the release workflow.

### What
<!-- List the content you worked on in bullet points -->
- Updated the `release.yaml` workflow to ensure quay.io images are scanned.
- Modified the `Scan images` step to include quay.io repository in the scanning process.

### Why
<!-- Explain the background to why you needed to do this PR 
It would be good if you could summarize it here so that it is complete without relying on other apps or related information -->
The quay.io images were not being scanned due to the missing repository loop in the `Scan images` step. This PR addresses the issue by adding quay.io to the list of repositories to be scanned.

### Ref
- https://github.com/cybozu/ubuntu-base/pull/340