### PR TITLE
Use more stable runner image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         ubuntu-version: ["20.04", "22.04", "24.04"]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ${{ matrix.ubuntu-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu-version: ["20.04", "22.04", "24.04"]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ${{ matrix.ubuntu-version }}
@@ -97,7 +97,7 @@ jobs:
 
   scan:
     name: Scan images
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: release
     env:
       YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.CYBOZU_NECO_PAT }}
       UBUNTU_VERSION: "20.04 22.04 24.04"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
Temporarily use non-latest ubuntu-image to avoid CI error.