### PR TITLE
Update ubuntu-dev images to disable gh telemetry

### DIFF
--- a/22.04/ubuntu-dev/Dockerfile
+++ b/22.04/ubuntu-dev/Dockerfile
@@ -19,5 +19,8 @@ RUN curl -fsL -o /tmp/gh.tgz https://github.com/cli/cli/releases/download/v${GH_
     && mkdir -p /usr/share/doc/gh \
     && cp /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/LICENSE /usr/share/doc/gh/LICENSE \
     && rm -rf /tmp/gh_${GH_VERSION}_linux_${TARGETARCH} /tmp/gh.tgz
+# Disable gh telemetry: https://cli.github.com/telemetry
+ENV GH_TELEMETRY=false
+ENV DO_NOT_TRACK=true
 
 CMD ["/bin/bash"]

--- a/24.04/ubuntu-dev/Dockerfile
+++ b/24.04/ubuntu-dev/Dockerfile
@@ -19,5 +19,8 @@ RUN curl -fsL -o /tmp/gh.tgz https://github.com/cli/cli/releases/download/v${GH_
     && mkdir -p /usr/share/doc/gh \
     && cp /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/LICENSE /usr/share/doc/gh/LICENSE \
     && rm -rf /tmp/gh_${GH_VERSION}_linux_${TARGETARCH} /tmp/gh.tgz
+# Disable gh telemetry: https://cli.github.com/telemetry
+ENV GH_TELEMETRY=false
+ENV DO_NOT_TRACK=true
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Changes

- Disable gh telemetry: https://cli.github.com/telemetry 

## Test

### ubuntu-dev:22.04

```console
$ cd 22.04/ubuntu-dev
$ docker build -t ghcr.io/cybozu/ubuntu-dev:test-22.04 --build-arg TAG=22.04 .
$ docker run --rm -it ghcr.io/cybozu/ubuntu-dev:test-22.04 bash
root@11aed3f3c549:/# env | grep GH_TELEMETRY
GH_TELEMETRY=false
root@11aed3f3c549:/# env | grep DO_NOT_TRACK
DO_NOT_TRACK=true
```

### ubuntu-dev:24.04

```console
$ cd 24.04/ubuntu-dev
$ docker build -t ghcr.io/cybozu/ubuntu-dev:test-24.04 --build-arg TAG=24.04 .
$ docker run --rm -it ghcr.io/cybozu/ubuntu-dev:test-24.04 bash
root@f48ecaa6375e:/# env | grep GH_TELEMETRY
GH_TELEMETRY=false
root@f48ecaa6375e:/# env | grep DO_NOT_TRACK
DO_NOT_TRACK=true
```

