### PR TITLE
fix: improve container tag existence check in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,8 @@ jobs:
 
             NEED_PUSH=false
             for repo in ghcr.io quay.io; do
-              if ! container-tag-exists "${repo}/cybozu/${image_name}" "${tag_name}" >/dev/null 2>&1; then
+              c=$(container-tag-exists "${repo}/cybozu/${image_name}" "${tag_name}" 2>&1)
+              if [ "$c" = "" ]; then
                 NEED_PUSH=true
                 break
               fi


### PR DESCRIPTION
PR #545 rewrote the release workflow to use docker buildx bake, but introduced a bug in the "Check if images need to be pushed" step. The new code used ! container-tag-exists ... >/dev/null 2>&1 to determine whether a push was needed, relying on the exit code. However, container-tag-exists exits with 0 regardless of whether the tag exists or not — it only exits non-zero on errors. As a result, NEED_PUSH was never set to true, and the build & push step was always skipped.

This went unnoticed until PR #568 bumped the TAG to 20260608 and merged — the release job silently skipped pushing the new images, leaving ghcr.io/cybozu/ubuntu:22.04.20260608 (and [24.04](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) unpublished. The subsequent update job then failed with manifest unknown when trying to docker pull those missing tags.

Fix: Revert to the original pattern of capturing stdout into a variable and checking whether the output is empty