### PR TITLE
Stop using container-tag-exists

### DIFF
--- a/.github/actions/check-push/action.yaml
+++ b/.github/actions/check-push/action.yaml
@@ -1,0 +1,60 @@
+name: "Check if images need to be pushed"
+description: "Check whether release images are missing from container registries."
+inputs:
+  ubuntu_version:
+    description: Ubuntu version to check.
+    required: true
+outputs:
+  needs-push:
+    description: Whether any image needs to be pushed.
+    value: ${{ steps.check-push.outputs.needs-push }}
+  targets:
+    description: Space-separated bake targets that need to be pushed.
+    value: ${{ steps.check-push.outputs.targets }}
+runs:
+  using: composite
+  steps:
+    - name: Check if images need to be pushed
+      id: check-push
+      shell: bash
+      run: |
+        TARGETS=()
+        tag_minimal=$(cat "${{ inputs.ubuntu_version }}/TAG_MINIMAL")
+        tag=$(cat "${{ inputs.ubuntu_version }}/TAG")
+
+        for image_name in ubuntu-minimal ubuntu ubuntu-dev ubuntu-debug; do
+          if [[ "$image_name" == "ubuntu-minimal" ]]; then
+            tag_name="$tag_minimal"
+          else
+            tag_name="$tag"
+          fi
+
+          NEED_PUSH=false
+
+          for repo in ghcr.io quay.io; do
+            FOUND=$(./scripts/tag_exists "${repo}/cybozu/${image_name}" "${tag_name}")
+            case "$FOUND" in
+            true | false)
+              ;;
+            *)
+              echo "Error: unexpected tag_exists output for ${repo}/cybozu/${image_name}:${tag_name}: ${FOUND}" >&2
+              exit 1
+              ;;
+            esac
+
+            if [[ "$FOUND" == "false" ]]; then
+              NEED_PUSH=true
+            fi
+          done
+
+          if [[ "$NEED_PUSH" == "true" ]]; then
+            TARGETS+=("${image_name}")
+          fi
+        done
+
+        echo "targets=${TARGETS[*]}" >> "$GITHUB_OUTPUT"
+        if [[ ${#TARGETS[@]} -eq 0 ]]; then
+          echo "needs-push=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "needs-push=true" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/check-push/action.yaml
+++ b/.github/actions/check-push/action.yaml
@@ -54,7 +54,23 @@ runs:
 
         echo "targets=${TARGETS[*]}" >> "$GITHUB_OUTPUT"
         if [[ ${#TARGETS[@]} -eq 0 ]]; then
+          echo "Images to push for Ubuntu ${{ inputs.ubuntu_version }}: none"
           echo "needs-push=false" >> "$GITHUB_OUTPUT"
         else
+          echo "Images to push for Ubuntu ${{ inputs.ubuntu_version }}: ${TARGETS[*]}"
           echo "needs-push=true" >> "$GITHUB_OUTPUT"
         fi
+
+        {
+          echo "### Push targets for Ubuntu ${{ inputs.ubuntu_version }}"
+          echo
+          if [[ ${#TARGETS[@]} -eq 0 ]]; then
+            echo "No images need to be pushed."
+          else
+            echo "The following images need to be pushed:"
+            echo
+            for target in "${TARGETS[@]}"; do
+              echo "- \`${target}\`"
+            done
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,6 @@
 name: build
 on:
   pull_request:
-env:
-  go-version: 1.26
 jobs:
   build:
     name: Build images
@@ -20,10 +18,6 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Setup golang
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ env.go-version }}
       - name: Resolve build variables
         run: |
           UBUNTU_VERSION=${{ matrix.ubuntu-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,11 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "DIGEST_DOCKERHUB_UBUNTU=${DIGEST_DOCKERHUB_UBUNTU}" >> $GITHUB_ENV
 
+      - name: Check if images need to be pushed
+        uses: ./.github/actions/check-push
+        with:
+          ubuntu_version: ${{ matrix.ubuntu-version }}
+
       - name: Build images
         run: |
           echo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - 'main'
-env:
-  go-version: 1.26
 jobs:
   release:
     name: Build and release images
@@ -32,12 +30,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup golang
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
-          go-version: ${{ env.go-version }}
-      - name: Install container-tag-exists
-        run: go install github.com/Hsn723/container-tag-exists@v1.2.5
+          aqua_version: v2.60.0
       - name: Resolve build variables
         run: |
           echo "UBUNTU_VERSION=${{ matrix.ubuntu-version }}" >> $GITHUB_ENV
@@ -58,8 +53,8 @@ jobs:
 
             NEED_PUSH=false
             for repo in ghcr.io quay.io; do
-              c=$(container-tag-exists "${repo}/cybozu/${image_name}" "${tag_name}" 2>&1)
-              if [ "$c" = "" ]; then
+              FOUND=$(./scripts/tag_exists "${repo}/cybozu/${image_name}" "${tag_name}")
+              if [[ "$FOUND" == "false" ]]; then
                 NEED_PUSH=true
                 break
               fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
-        with:
-          aqua_version: v2.60.0
       - name: Resolve build variables
         run: |
           echo "UBUNTU_VERSION=${{ matrix.ubuntu-version }}" >> $GITHUB_ENV
@@ -41,38 +38,9 @@ jobs:
           echo "DIGEST_DOCKERHUB_UBUNTU=$(cat ${{ matrix.ubuntu-version }}/DIGEST_DOCKERHUB_UBUNTU)" >> $GITHUB_ENV
       - name: Check if images need to be pushed
         id: check-push
-        run: |
-          TARGETS=()
-
-          for image_name in ubuntu-minimal ubuntu ubuntu-dev ubuntu-debug; do
-            if [[ "$image_name" == "ubuntu-minimal" ]]; then
-              tag_name="$TAG_MINIMAL"
-            else
-              tag_name="$TAG"
-            fi
-
-            NEED_PUSH=false
-            for repo in ghcr.io quay.io; do
-              FOUND=$(./scripts/tag_exists "${repo}/cybozu/${image_name}" "${tag_name}")
-              if [[ "$FOUND" == "false" ]]; then
-                NEED_PUSH=true
-                break
-              fi
-            done
-
-            if [[ "$NEED_PUSH" == "true" ]]; then
-              TARGETS+=("${image_name}")
-            fi
-          done
-
-          if [[ ${#TARGETS[@]} -eq 0 ]]; then
-            echo "needs-push=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs-push=true" >> "$GITHUB_OUTPUT"
-            echo "targets=${TARGETS[*]}" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/check-push
+        with:
+          ubuntu_version: ${{ matrix.ubuntu-version }}
       - name: Build and push images with bake
         if: steps.check-push.outputs.needs-push == 'true'
         env:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
-        with:
-          aqua_version: v2.60.0
       - name: Check minimal image updates
         shell: bash -xe {0}
         run: |

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.60.0
       - name: Check minimal image updates
         shell: bash -xe {0}
         run: |

--- a/scripts/tag_exists
+++ b/scripts/tag_exists
@@ -1,0 +1,59 @@
+#!/bin/sh -e
+# tag_exists <REGISTRY>/<ORG>/<PACKAGE> <TAG>
+
+if [ $# -ne 2 ]; then
+    echo "Error: tag_exists needs two arguments" >&2
+    exit 1
+fi
+
+IMAGE="$1"
+TAG="$2"
+
+REGISTRY=$(echo "${IMAGE}" | cut -d/ -f1)
+ORG=$(echo "${IMAGE}" | cut -d/ -f2)
+PACKAGE=$(echo "${IMAGE}" | cut -d/ -f3-)
+
+if [ -z "${REGISTRY}" ] || [ -z "${ORG}" ] || [ -z "${PACKAGE}" ]; then
+    echo "Error: invalid image format (expected: <registry>/<org>/<package>)" >&2
+    exit 1
+fi
+
+TAG_ENC=$(echo "${TAG}" | jq -Rr '@uri')
+
+ACCEPT="application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json"
+
+manifest_exists() {
+    STATUS=$(curl -sSI -o /dev/null -w '%{http_code}' "$@" || true)
+    case "${STATUS}" in
+    200)
+        echo true
+        ;;
+    401 | 403 | 404)
+        echo false
+        ;;
+    *)
+        echo "Error: failed to check tag existence (HTTP ${STATUS})" >&2
+        exit 1
+        ;;
+    esac
+}
+
+case "${REGISTRY}" in
+ghcr.io)
+    SCOPE_ENC=$(echo "repository:${ORG}/${PACKAGE}:pull" | jq -Rr '@uri')
+    TOKEN=$(curl -fsSL "https://ghcr.io/token?service=ghcr.io&scope=${SCOPE_ENC}" | jq -r .token)
+    manifest_exists \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Accept: ${ACCEPT}" \
+        "https://ghcr.io/v2/${ORG}/${PACKAGE}/manifests/${TAG_ENC}"
+    ;;
+quay.io)
+    manifest_exists \
+        -H "Accept: ${ACCEPT}" \
+        "https://quay.io/v2/${ORG}/${PACKAGE}/manifests/${TAG_ENC}"
+    ;;
+*)
+    echo "Error: unsupported registry '${REGISTRY}'" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
FYI: https://github.com/Hsn723/container-tag-exists/releases/tag/v1.2.5

It is in maintenance mode, so stop using container-tag-exists

I have created a script (tag_exists) that checks for the presence of tags on ghcr.io and have switched to using that. I also removed "Set up Go" because it appeared that Go was only being used to build and install container-tag-exists