### PR TITLE
revive image scan

### DIFF
--- a/.github/actions/setup-cosign/action.yaml
+++ b/.github/actions/setup-cosign/action.yaml
@@ -1,0 +1,20 @@
+name: Setup cosign
+description: "This action installs cosign CLI using fixed version cosign-installer action."
+runs:
+  using: composite
+  steps:
+    # cosign-installer requires envsubst command to be installed.
+    # However, it does not exist in ubuntu-slim runner.
+    # ref: https://github.com/sigstore/cosign-installer/issues/222
+    - name: Install envsubst used in cosign-installer action
+      shell: bash
+      run: |
+        if ! command -v envsubst &>/dev/null; then
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            gettext-base
+        fi
+    - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+    - run: |
+        cosign version
+      shell: bash

--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -1,0 +1,65 @@
+name: Setup Trivy
+description: Setup Trivy for scanning container images
+inputs:
+  trivy-version:
+    default: "0.70.0"
+runs:
+  using: composite
+  steps:
+    - env:
+        TRIVY_VERSION: "${{ inputs.trivy-version }}"
+      run: |
+        set -x
+        TRIVY_RELEASE_URL="https://cli.yamory.io/trivy/${TRIVY_VERSION}"
+        TRIVY_TAR="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+        ARTIFACT="/tmp/${TRIVY_TAR}"
+
+        echo "::group::Download artifacts"
+        wget -O "${ARTIFACT}" "${TRIVY_RELEASE_URL}/${TRIVY_TAR}"
+        wget -O "${ARTIFACT}.sigstore.json" "${TRIVY_RELEASE_URL}/${TRIVY_TAR}.sigstore.json"
+        echo "::endgroup::"
+
+        echo "::group::Check signature"
+        # https://docs.yamory.io/35d9ca090120803f8b51d6a50d6ce3e0#block-36b9ca0901208085a6fbdea3fafdc0f5
+        cosign verify-blob \
+          --bundle "${ARTIFACT}.sigstore.json" \
+          --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+          --certificate-identity "https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v${TRIVY_VERSION}" \
+          "${ARTIFACT}"
+        echo "::endgroup::"
+
+        # https://docs.yamory.io/35d9ca090120803f8b51d6a50d6ce3e0#block-36b9ca090120808ca7fef8760e2b106c
+        echo "::group::Check Provenance"
+        DIGEST=$(sha256sum "${ARTIFACT}" | cut -d' ' -f1)
+        curl -L "https://api.github.com/repos/aquasecurity/trivy/attestations/sha256:$DIGEST" | \
+        jq -r '.attestations[] | select(.initiator == "user") | .bundle' > bundle.json
+        cosign verify-blob-attestation \
+          --bundle bundle.json \
+          --new-bundle-format \
+          --certificate-identity "https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v${TRIVY_VERSION}" \
+          --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+          "${ARTIFACT}"
+        echo "::endgroup::"
+
+        echo "::group::Check the commit is signed"
+        SOURCE_HASH=`cat bundle.json | \
+          jq -r '.dsseEnvelope.payload' | base64 -d | \
+          jq -r '.predicate.buildDefinition.resolvedDependencies[] | select(.uri | startswith("git+https://github.com/aquasecurity/trivy@refs/tags/")) | .digest.gitCommit'`
+        echo ${SOURCE_HASH}
+        COMMIT_SIGN=$(curl -s -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/aquasecurity/trivy/commits/${SOURCE_HASH}" | \
+          jq '.commit.verification')
+        if [ "$(echo ${COMMIT_SIGN} | jq -r '.verified')" != "true" ]; then
+          echo "The commit is not signed"
+          exit 1
+        fi
+        echo "::endgroup::"
+
+        echo "::group::Install trivy"
+        tar -xzf "${ARTIFACT}" -C /tmp
+        chmod +x /tmp/trivy
+        mv /tmp/trivy /usr/local/bin/
+        rm -f "${ARTIFACT}" "${ARTIFACT}.sigstore.json" bundle.json
+        trivy --version
+        echo "::endgroup::"
+      shell: bash

--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -58,6 +58,7 @@ runs:
         echo "::group::Install trivy"
         tar -xzf "${ARTIFACT}" -C /tmp
         chmod +x /tmp/trivy
+        # Install the Trivy binary where the Yamory scan script looks for it.
         mv /tmp/trivy /usr/local/bin/
         rm -f "${ARTIFACT}" "${ARTIFACT}.sigstore.json" bundle.json
         trivy --version

--- a/.github/actions/setup-yamory-scripts/action.yaml
+++ b/.github/actions/setup-yamory-scripts/action.yaml
@@ -1,0 +1,25 @@
+name: Setup yamory scripts
+description: "This action sets up yamory scripts for container scanning."
+runs:
+  using: composite
+  steps:
+    - name: Setup yamory scripts
+      shell: bash
+      run: |
+        TMP_DIR=$(mktemp -d)
+
+        echo "::group::Download yamory scripts"
+        curl -o "${TMP_DIR}/image_scan.sh" -sSf -L https://mw-receiver.yamory.io/image/script/trivy
+        # https://docs.yamory.io/8305180d94ba4a5299304ec6429dc582
+        curl -o "${TMP_DIR}/image_scan_sha512sum.txt" -sSf -L https://cli.yamory.io/yamory-image-scan-scripts/image_scan_sha512sum.txt
+        echo "::endgroup::"
+
+        echo "::group::Verify checksum"
+        cd "${TMP_DIR}" && sha512sum -c image_scan_sha512sum.txt
+        echo "::endgroup::"
+
+        echo "::group::Install yamory scripts"
+        chmod +x "${TMP_DIR}/image_scan.sh"
+        mv "${TMP_DIR}/image_scan.sh" /usr/local/bin/yamory-image-scan
+        rm -rf "${TMP_DIR}"
+        echo "::endgroup::"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,58 @@ jobs:
           docker buildx bake -f docker-bake.hcl \
             --push \
             $TARGETS
+      - name: Write scan targets
+        env:
+          TARGETS: ${{ steps.check-push.outputs.targets }}
+        run: |
+          printf "%s\n" "$TARGETS" > scan-targets.txt
+      - name: Upload scan targets
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: scan-targets-${{ matrix.ubuntu-version }}
+          path: scan-targets.txt
+  scan-image:
+    needs: release
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        ubuntu-version: ["22.04", "24.04"]
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: scan-targets-${{ matrix.ubuntu-version }}
+          path: scan-targets.txt
+      - uses: ./.github/actions/setup-cosign
+      - uses: ./.github/actions/setup-trivy
+      - uses: ./.github/actions/setup-yamory-scripts
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Scan images
+        env:
+          YAMORY_ACCESS_TOKEN: ${{ secrets.YAMORY_ACCESS_TOKEN }}
+          UBUNTU_VERSION: ${{ matrix.ubuntu-version }}
+        run: |
+          TARGETS=$(cat scan-targets.txt)
+          if [[ -z "$TARGETS" ]]; then
+            echo "No images to scan."
+            exit 0
+          fi
+
+          while read -r image; do
+            if [[ "$image" == "ubuntu-minimal" ]]; then
+              TAG=$(cat "${UBUNTU_VERSION}/TAG_MINIMAL")
+            else
+              TAG=$(cat "${UBUNTU_VERSION}/TAG")
+            fi
+            export YAMORY_IMAGE_NAME="ghcr.io/cybozu/$image:$TAG"
+            export YAMORY_IMAGE_IDENTIFIER="ghcr.io/cybozu/$image:${UBUNTU_VERSION}"
+            yamory-image-scan
+          done < scan-targets.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         env:
           TARGETS: ${{ steps.check-push.outputs.targets }}
         run: |
-          printf "%s\n" "$TARGETS" > scan-targets.txt
+          printf "%s\n" $TARGETS > scan-targets.txt
       - name: Upload scan targets
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -70,10 +70,10 @@ jobs:
       packages: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: scan-targets-${{ matrix.ubuntu-version }}
-          path: scan-targets.txt
+          path: .
       - uses: ./.github/actions/setup-cosign
       - uses: ./.github/actions/setup-trivy
       - uses: ./.github/actions/setup-yamory-scripts


### PR DESCRIPTION
Container image scanning was previously suspended due to the impact of an incident involving Trivy. #524 #533 
In accordance with our internal policies, we will be reinstating these container image scanning mechanisms.


However, the implementation must adhere to the following points:


- Mandatory verification of Trivy binaries using cosign
- Prohibition of executing Trivy and Yamory scripts within workflows that have `packages: write` permissions
  - Having write access poses a significant risk
- Executing image push and scan as separate jobs
  - If performed within the same job, it becomes impossible to retry the scan if the push succeeds but the scan fails
