### PR TITLE
specify --type slsaprovenance1 explicitly

### DIFF
--- a/.github/actions/setup-trivy/action.yaml
+++ b/.github/actions/setup-trivy/action.yaml
@@ -36,6 +36,7 @@ runs:
         cosign verify-blob-attestation \
           --bundle bundle.json \
           --new-bundle-format \
+          --type slsaprovenance1 \
           --certificate-identity "https://github.com/aquasecurity/trivy/.github/workflows/reusable-release.yaml@refs/tags/v${TRIVY_VERSION}" \
           --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
           "${ARTIFACT}"


### PR DESCRIPTION
Latest cosign command fixes the bug that skipping DSSE predicate check.
https://github.com/sigstore/cosign/pull/4801

We should specify the type explicitly to check attestations.