### PR TITLE
Remove quay.io push and consolidate registry to ghcr.io

### DIFF
--- a/.github/actions/check-push/action.yaml
+++ b/.github/actions/check-push/action.yaml
@@ -31,21 +31,19 @@ runs:
 
           NEED_PUSH=false
 
-          for repo in ghcr.io quay.io; do
-            FOUND=$(./scripts/tag_exists "${repo}/cybozu/${image_name}" "${tag_name}")
-            case "$FOUND" in
-            true | false)
-              ;;
-            *)
-              echo "Error: unexpected tag_exists output for ${repo}/cybozu/${image_name}:${tag_name}: ${FOUND}" >&2
-              exit 1
-              ;;
-            esac
+          FOUND=$(./scripts/tag_exists "ghcr.io/cybozu/${image_name}" "${tag_name}")
+          case "$FOUND" in
+          true | false)
+            ;;
+          *)
+            echo "Error: unexpected tag_exists output for ghcr.io/cybozu/${image_name}:${tag_name}: ${FOUND}" >&2
+            exit 1
+            ;;
+          esac
 
-            if [[ "$FOUND" == "false" ]]; then
-              NEED_PUSH=true
-            fi
-          done
+          if [[ "$FOUND" == "false" ]]; then
+            NEED_PUSH=true
+          fi
 
           if [[ "$NEED_PUSH" == "true" ]]; then
             TARGETS+=("${image_name}")

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Login to container registry
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ Simply copies the upstream Ubuntu image without any modifications.
 
 A standard Ubuntu base image with common utilities and tools.
 
-**Registry URLs:**
+**Registry URL:**
 - <https://github.com/cybozu/ubuntu-base/pkgs/container/ubuntu>
-- <https://quay.io/repository/cybozu/ubuntu>
 
 **Package Documentation:**
 - [ubuntu:22.04 Packages](docs/ubuntu-22.04.md)
@@ -26,9 +25,8 @@ A standard Ubuntu base image with common utilities and tools.
 
 A development-focused Ubuntu image that includes build tools, compilers, and development libraries.
 
-**Registry URLs:**
+**Registry URL:**
 - <https://github.com/cybozu/ubuntu-base/pkgs/container/ubuntu-dev>
-- <https://quay.io/repository/cybozu/ubuntu-dev>
 
 **Package Documentation:**
 - [ubuntu-dev:22.04 Packages](docs/ubuntu-dev-22.04.md)
@@ -38,9 +36,8 @@ A development-focused Ubuntu image that includes build tools, compilers, and dev
 
 A comprehensive debugging and troubleshooting Ubuntu image with extensive debugging tools, network utilities, and diagnostic software.
 
-**Registry URLs:**
+**Registry URL:**
 - <https://github.com/cybozu/ubuntu-base/pkgs/container/ubuntu-debug>
-- <https://quay.io/repository/cybozu/ubuntu-debug>
 
 **Package Documentation:**
 - [ubuntu-debug:22.04 Packages](docs/ubuntu-debug-22.04.md)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -46,10 +46,7 @@ target "ubuntu-minimal" {
     TAG_MINIMAL             = "${TAG_MINIMAL}"
     DIGEST_DOCKERHUB_UBUNTU = "${DIGEST_DOCKERHUB_UBUNTU}"
   }
-  tags = [
-    "ghcr.io/cybozu/ubuntu-minimal:${TAG_MINIMAL}",
-    "quay.io/cybozu/ubuntu-minimal:${TAG_MINIMAL}",
-  ]
+  tags = ["ghcr.io/cybozu/ubuntu-minimal:${TAG_MINIMAL}"]
 }
 
 target "ubuntu" {
@@ -65,8 +62,6 @@ target "ubuntu" {
   tags = [
     "ghcr.io/cybozu/ubuntu:${TAG}",
     "ghcr.io/cybozu/ubuntu:${UBUNTU_VERSION}",
-    "quay.io/cybozu/ubuntu:${TAG}",
-    "quay.io/cybozu/ubuntu:${UBUNTU_VERSION}",
   ]
 }
 
@@ -83,8 +78,6 @@ target "ubuntu-dev" {
   tags = [
     "ghcr.io/cybozu/ubuntu-dev:${TAG}",
     "ghcr.io/cybozu/ubuntu-dev:${UBUNTU_VERSION}",
-    "quay.io/cybozu/ubuntu-dev:${TAG}",
-    "quay.io/cybozu/ubuntu-dev:${UBUNTU_VERSION}",
   ]
 }
 
@@ -101,7 +94,5 @@ target "ubuntu-debug" {
   tags = [
     "ghcr.io/cybozu/ubuntu-debug:${TAG}",
     "ghcr.io/cybozu/ubuntu-debug:${UBUNTU_VERSION}",
-    "quay.io/cybozu/ubuntu-debug:${TAG}",
-    "quay.io/cybozu/ubuntu-debug:${UBUNTU_VERSION}",
   ]
 }

--- a/scripts/tag_exists
+++ b/scripts/tag_exists
@@ -47,11 +47,6 @@ ghcr.io)
         -H "Accept: ${ACCEPT}" \
         "https://ghcr.io/v2/${ORG}/${PACKAGE}/manifests/${TAG_ENC}"
     ;;
-quay.io)
-    manifest_exists \
-        -H "Accept: ${ACCEPT}" \
-        "https://quay.io/v2/${ORG}/${PACKAGE}/manifests/${TAG_ENC}"
-    ;;
 *)
     echo "Error: unsupported registry '${REGISTRY}'" >&2
     exit 1


### PR DESCRIPTION
This PR stops pushing container images to quay.io and consolidates image distribution to ghcr.io only.

The `QUAY_USER` / `QUAY_PASSWORD` secrets are no longer referenced and can be removed from the repository settings in a follow-up.

There is no reference to quay left.

```console
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/ubuntu-base$ 
k8s:> git grep -in quay
takahiro_yamada@pdx-ytk-dev:~/work/cybozu/ubuntu-base$ 
```